### PR TITLE
Rewrite packet parsing

### DIFF
--- a/quic.nimble
+++ b/quic.nimble
@@ -5,4 +5,5 @@ description = "QUIC protocol implementation"
 license = "MIT"
 
 requires "nim >= 1.2.6"
+requires "stew >= 0.1.0 & < 0.2.0"
 requires "https://github.com/status-im/nim-ngtcp2.git >= 0.1.0 & < 0.2.0"

--- a/quic/bits.nim
+++ b/quic/bits.nim
@@ -4,28 +4,16 @@ type
   Bit* = range[0'u8..1'u8]
   Bits* = distinct byte
   BitIndex = BitsRange[byte]
-  Bytes* = distinct uint32
-  ByteIndex* = range[0..sizeof(uint32)-1]
 
 proc lsb(index: BitIndex): BitsRange[byte] =
   ### Converts a bit index from MSB 0 to LSB 0
   BitsRange[byte].high - BitsRange[byte](index)
-
-proc lsb(index: ByteIndex): ByteIndex =
-  ## Converts a byte index from MSB 0 to LSB 0
-  ByteIndex.high - index
 
 proc `[]`*(bits: Bits, index: BitIndex): Bit =
   ## Returns the bit at the specified index.
   ## Uses MSB 0 bit numbering, so an `index`
   ## of 0 indicates the most significant bit.
   testBit[byte](bits.byte, index.lsb).Bit
-
-proc `[]`*(bytes: Bytes, index: ByteIndex): byte =
-  ## Returns the byte at the specified index.
-  ## Uses MSB 0 byte numbering, so an `index`
-  ## of 0 indicates the most significant byte.
-  byte(uint32(bytes) shr (index.lsb * 8))
 
 proc `[]=`*(bits: var Bits, index: BitIndex, value: Bit) =
   ## Sets the bit at the specified index.
@@ -35,20 +23,8 @@ proc `[]=`*(bits: var Bits, index: BitIndex, value: Bit) =
   of 0: clearBit[byte](bits.byte, index.lsb)
   of 1: setBit[byte](bits.byte, index.lsb)
 
-proc `[]=`*(bytes: var Bytes, index: ByteIndex, value: byte) =
-  ## Sets the byte at the specified index.
-  ## Uses MSB 0 byte numbering, so an `index`
-  ## of 0 indicates the most significant byte.
-  bytes = Bytes(uint32(bytes) or (uint32(value) shl (index.lsb * 8)))
-
 proc bits*(value: byte): Bits =
   Bits(value)
 
 proc bits*(value: var byte): var Bits =
   Bits(value)
-
-proc bytes*(value: uint32): Bytes =
-  Bytes(value)
-
-proc bytes*(value: var uint32): var Bytes =
-  Bytes(value)

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -1,6 +1,5 @@
 import math
 import strutils
-import strformat
 import bits
 
 type
@@ -154,26 +153,6 @@ proc write*(datagram: var seq[byte], header: Packet) =
 
 proc `$`*(id: ConnectionId): string =
   "0x" & cast[string](id).toHex
-
-proc `$`*(header: Packet): string =
-  case header.form:
-  of formShort:
-    fmt"(form: {header.form})"
-  else:
-    case header.kind:
-    of packetVersionNegotiation:
-      "(" &
-        fmt"kind: {header.kind}, " &
-        fmt"destination: {header.destination}, " &
-        fmt"source: {header.source}, " &
-        fmt"supportedVersion: {header.negotiation.supportedVersion}" &
-      ")"
-    else:
-      "(" &
-        fmt"kind: {header.kind}, " &
-        fmt"destination: {header.destination}, " &
-        fmt"source: {header.source}" &
-      ")"
 
 proc `==`*(x: ConnectionId, y: ConnectionId): bool {.borrow.}
 proc `len`*(x: ConnectionId): int {.borrow.}

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -43,9 +43,9 @@ proc readPacket*(datagram: Datagram): Packet =
   else:
     readLongPacket(datagram)
 
-proc write*(datagram: var Datagram, header: Packet) =
-  datagram.writeForm(header)
+proc write*(datagram: var Datagram, packet: Packet) =
+  datagram.writeForm(packet)
   datagram.writeFixedBit()
-  if header.form == formLong:
-    datagram.writeKind(header)
-    datagram.writeVersion(header)
+  if packet.form == formLong:
+    datagram.writeKind(packet)
+    datagram.writeVersion(packet)

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -81,12 +81,12 @@ proc writeVersion*(datagram: var Datagram, header: Packet) =
 
 proc readKind(datagram: Datagram): PacketKind =
   if datagram.readVersion() == 0:
-    result = packetVersionNegotiation
+    packetVersionNegotiation
   else:
     var kind: uint8
     kind.bits[6] = datagram[0].bits[2]
     kind.bits[7] = datagram[0].bits[3]
-    result = PacketKind(kind)
+    PacketKind(kind)
 
 proc writeKind(datagram: var Datagram, header: Packet) =
   case header.kind:
@@ -99,23 +99,23 @@ proc writeKind(datagram: var Datagram, header: Packet) =
 proc findDestination(datagram: Datagram): Slice[int] =
   let start = 6
   let length = datagram[5].int
-  result = start..<start+length
+  start..<start+length
 
 proc readDestination*(datagram: Datagram): ConnectionId =
-  result = ConnectionId(datagram[datagram.findDestination()])
+  ConnectionId(datagram[datagram.findDestination()])
 
 proc findSource(datagram: Datagram): Slice[int] =
   let destinationEnd = datagram.findDestination().b + 1
   let start = destinationEnd + 1
   let length = datagram[destinationEnd].int
-  result = start..<start+length
+  start..<start+length
 
 proc readSource(datagram: Datagram): ConnectionId =
-  result = ConnectionId(datagram[datagram.findSource()])
+  ConnectionId(datagram[datagram.findSource()])
 
 proc findSupportedVersion(datagram: Datagram): Slice[int] =
   let start = datagram.findSource().b + 1
-  result = start..<start+4
+  start..<start+4
 
 proc readSupportedVersion*(datagram: Datagram): uint32 =
   let versionBytes = datagram[datagram.findSupportedVersion()]
@@ -125,7 +125,7 @@ proc readSupportedVersion*(datagram: Datagram): uint32 =
   result.bytes[3] = versionBytes[3]
 
 proc readVersionNegotiation(datagram: Datagram): Packet =
-  result = Packet(
+  Packet(
     form: formLong,
     kind: packetVersionNegotiation,
     destination: datagram.readDestination(),
@@ -154,9 +154,9 @@ proc readPacket*(datagram: Datagram): Packet =
   datagram.readFixedBit()
   case form
   of formShort:
-    result = Packet(form: form)
+    Packet(form: form)
   else:
-    result = readLongPacket(datagram)
+    readLongPacket(datagram)
 
 proc write*(datagram: var Datagram, header: Packet) =
   datagram.writeForm(header)

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -1,6 +1,7 @@
 import math
 import strutils
 import bits
+import stew/endians2
 
 {.push raises:[].} # avoid exceptions in this module
 
@@ -54,10 +55,7 @@ proc writeFixedBit(datagram: var Datagram) =
   datagram[0].bits[1] = 1
 
 proc readVersion(datagram: Datagram): uint32 =
-  result.bytes[0] = datagram[1]
-  result.bytes[1] = datagram[2]
-  result.bytes[2] = datagram[3]
-  result.bytes[3] = datagram[4]
+  fromBytesBE(uint32, datagram[1..4])
 
 proc version*(header: Packet): uint32 =
   case header.kind
@@ -76,10 +74,11 @@ proc `version=`*(header: var Packet, version: uint32) =
   of packetVersionNegotiation: discard
 
 proc writeVersion*(datagram: var Datagram, header: Packet) =
-  datagram[1] = header.version.bytes[0]
-  datagram[2] = header.version.bytes[1]
-  datagram[3] = header.version.bytes[2]
-  datagram[4] = header.version.bytes[3]
+  let bytes = toBytesBE(header.version)
+  datagram[1] = bytes[0]
+  datagram[2] = bytes[1]
+  datagram[3] = bytes[2]
+  datagram[4] = bytes[3]
 
 proc readKind(datagram: Datagram): PacketKind =
   if datagram.readVersion() == 0:
@@ -121,10 +120,7 @@ proc findSupportedVersion(datagram: Datagram): Slice[int] =
 
 proc readSupportedVersion*(datagram: Datagram): uint32 =
   let versionBytes = datagram[datagram.findSupportedVersion()]
-  result.bytes[0] = versionBytes[0]
-  result.bytes[1] = versionBytes[1]
-  result.bytes[2] = versionBytes[2]
-  result.bytes[3] = versionBytes[3]
+  fromBytesBE(uint32, versionBytes)
 
 proc readVersionNegotiation(datagram: Datagram): Packet =
   Packet(

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -73,21 +73,6 @@ proc destination*(header: PacketHeader): ConnectionId =
 proc source*(header: PacketHeader): ConnectionId =
   result = ConnectionId(header.bytes[header.sourceSlice])
 
-proc `$`*(id: ConnectionId): string =
-  "0x" & cast[string](id).toHex
-
-proc `$`*(header: PacketHeader): string =
-  case header.form:
-  of headerShort: fmt"(form: {header.form})"
-  of headerLong: "(" &
-      fmt"form: {header.form}, " &
-      fmt"kind: {header.kind}, " &
-      fmt"destination: {header.destination}, " &
-      fmt"source: {header.source}" &
-    ")"
-
-proc `==`*(x: ConnectionId, y: ConnectionId): bool {.borrow.}
-
 proc supportedVersionSlice(header: PacketHeader): Slice[int] =
   let start = header.sourceSlice().b + 1
   result = start..<start+4
@@ -98,6 +83,33 @@ proc supportedVersion*(header: PacketHeader): uint32 =
   result.bytes[1] = versionBytes[1]
   result.bytes[2] = versionBytes[2]
   result.bytes[3] = versionBytes[3]
+
+proc `$`*(id: ConnectionId): string =
+  "0x" & cast[string](id).toHex
+
+proc `$`*(header: PacketHeader): string =
+  case header.form:
+  of headerShort: fmt"(form: {header.form})"
+  of headerLong:
+    case header.kind:
+    of packetVersionNegotiation:
+      "(" &
+        fmt"form: {header.form}, " &
+        fmt"kind: {header.kind}, " &
+        fmt"destination: {header.destination}, " &
+        fmt"source: {header.source}, " &
+        fmt"supportedVersion: {header.supportedVersion}" &
+      ")"
+    else:
+      "(" &
+        fmt"form: {header.form}, " &
+        fmt"kind: {header.kind}, " &
+        fmt"destination: {header.destination}, " &
+        fmt"source: {header.source}" &
+      ")"
+
+proc `==`*(x: ConnectionId, y: ConnectionId): bool {.borrow.}
+
 proc packetLength*(header: PacketHeader): int =
   case header.kind:
   of packetVersionNegotiation:

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -154,21 +154,6 @@ proc write*(datagram: var seq[byte], header: Packet) =
     datagram.writeKind(header)
     datagram.writeVersion(header)
 
-proc destinationSlice(header: Packet): Slice[int] =
-  let start = 6
-  let length = header.bytes[5].int
-  result = start..<start+length
-
-proc sourceSlice(header: Packet): Slice[int] =
-  let destinationEnd = header.destinationSlice.b + 1
-  let start = destinationEnd + 1
-  let length = header.bytes[destinationEnd].int
-  result = start..<start+length
-
-proc supportedVersionSlice(header: Packet): Slice[int] =
-  let start = header.sourceSlice().b + 1
-  result = start..<start+4
-
 proc `$`*(id: ConnectionId): string =
   "0x" & cast[string](id).toHex
 
@@ -193,10 +178,11 @@ proc `$`*(header: Packet): string =
       ")"
 
 proc `==`*(x: ConnectionId, y: ConnectionId): bool {.borrow.}
+proc `len`*(x: ConnectionId): int {.borrow.}
 
 proc packetLength*(header: Packet): int =
   case header.kind:
   of packetVersionNegotiation:
-    return header.supportedVersionSlice.b + 1
+    return 11 + header.destination.len + header.source.len
   else:
     return 0

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -53,8 +53,14 @@ proc writeKind(datagram: var seq[byte], kind: PacketKind) =
       datagram[0].bits[2] = kind.uint8.bits[6]
       datagram[0].bits[3] = kind.uint8.bits[7]
 
-proc newPacketHeader*(datagram: seq[byte]): PacketHeader =
+proc readFixedBit(datagram: seq[byte]) =
   assert datagram[0].bits[1] == 1
+
+proc writeFixedBit(datagram: var seq[byte]) =
+  datagram[0].bits[1] = 1
+
+proc newPacketHeader*(datagram: seq[byte]): PacketHeader =
+  datagram.readFixedBit()
   PacketHeader(kind: datagram.readKind(), bytes: datagram)
 
 proc newShortPacketHeader*(): PacketHeader =
@@ -62,6 +68,7 @@ proc newShortPacketHeader*(): PacketHeader =
 
 proc write*(datagram: var seq[byte], header: PacketHeader) =
   datagram[0..<header.bytes.len] = header.bytes
+  datagram.writeFixedBit()
   datagram.writeKind(header.kind)
 
 proc version*(header: PacketHeader): uint32 =

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -2,6 +2,8 @@ import math
 import strutils
 import bits
 
+{.push raises:[].} # avoid exceptions in this module
+
 type
   ConnectionId* = distinct seq[byte]
   PacketForm* = enum

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -20,8 +20,8 @@ proc newPacketHeader*(bytes: seq[byte]): PacketHeader =
   assert bytes[0].bits[1] == 1
   PacketHeader(bytes: bytes)
 
-proc bytes*(header: PacketHeader): seq[byte] =
-  header.bytes
+proc write*(datagram: var seq[byte], header: PacketHeader) =
+  datagram[0..<header.bytes.len] = header.bytes
 
 proc version*(header: PacketHeader): uint32 =
   result.bytes[0] = header.bytes[1]

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -157,9 +157,6 @@ proc readPacket*(datagram: seq[byte]): Packet =
   else:
     result = readLongPacket(datagram)
 
-proc newShortPacket*(): Packet =
-  Packet(form: formShort)
-
 proc write*(datagram: var seq[byte], header: Packet) =
   datagram.writeForm(header)
   datagram.writeFixedBit()

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -1,126 +1,13 @@
-import math
-import strutils
-import bits
-import stew/endians2
+import packets/datagram
+import packets/packet
+import packets/length
+import packets/read
+import packets/write
+export datagram
+export packet
+export length
 
 {.push raises:[].} # avoid exceptions in this module
-
-type
-  ConnectionId* = distinct seq[byte]
-  PacketForm* = enum
-    formShort
-    formLong
-  PacketKind* = enum
-    packetInitial
-    packet0RTT
-    packetHandshake
-    packetRetry
-    packetVersionNegotiation
-  HeaderInitial* = object
-    version*: uint32
-  Header0RTT* = object
-    version*: uint32
-  HeaderHandshake* = object
-    version*: uint32
-  HeaderRetry* = object
-    version*: uint32
-  HeaderVersionNegotiation* = object
-    supportedVersion*: uint32
-  Packet* = object
-    case form*: PacketForm
-    of formShort:
-      discard
-    of formLong:
-      case kind*: PacketKind
-      of packetInitial: initial*: HeaderInitial
-      of packet0RTT: rtt*: Header0RTT
-      of packetHandshake: handshake*: HeaderHandshake
-      of packetRetry: retry*: HeaderRetry
-      of packetVersionNegotiation: negotiation*: HeaderVersionNegotiation
-      destination*: ConnectionId
-      source*: ConnectionId
-  PacketNumber* = range[0'u64..2'u64^62-1]
-  Datagram* = openArray[byte]
-
-proc readForm(datagram: Datagram): PacketForm =
-  PacketForm(datagram[0].bits[0])
-
-proc writeForm(datagram: var Datagram, header: Packet) =
-  datagram[0].bits[0] = Bit(header.form)
-
-proc readFixedBit(datagram: Datagram) =
-  doAssert datagram[0].bits[1] == 1
-
-proc writeFixedBit(datagram: var Datagram) =
-  datagram[0].bits[1] = 1
-
-proc readVersion(datagram: Datagram): uint32 =
-  fromBytesBE(uint32, datagram[1..4])
-
-proc version*(header: Packet): uint32 =
-  case header.kind
-  of packetInitial: header.initial.version
-  of packet0RTT: header.rtt.version
-  of packetHandshake: header.handshake.version
-  of packetRetry: header.retry.version
-  of packetVersionNegotiation: 0
-
-proc `version=`*(header: var Packet, version: uint32) =
-  case header.kind
-  of packetInitial: header.initial.version = version
-  of packet0RTT: header.rtt.version = version
-  of packetHandshake: header.handshake.version = version
-  of packetRetry: header.retry.version = version
-  of packetVersionNegotiation: discard
-
-proc writeVersion*(datagram: var Datagram, header: Packet) =
-  let bytes = toBytesBE(header.version)
-  datagram[1] = bytes[0]
-  datagram[2] = bytes[1]
-  datagram[3] = bytes[2]
-  datagram[4] = bytes[3]
-
-proc readKind(datagram: Datagram): PacketKind =
-  if datagram.readVersion() == 0:
-    packetVersionNegotiation
-  else:
-    var kind: uint8
-    kind.bits[6] = datagram[0].bits[2]
-    kind.bits[7] = datagram[0].bits[3]
-    PacketKind(kind)
-
-proc writeKind(datagram: var Datagram, header: Packet) =
-  case header.kind:
-  of packetVersionNegotiation:
-    discard
-  else:
-    datagram[0].bits[2] = header.kind.uint8.bits[6]
-    datagram[0].bits[3] = header.kind.uint8.bits[7]
-
-proc findDestination(datagram: Datagram): Slice[int] =
-  let start = 6
-  let length = datagram[5].int
-  start..<start+length
-
-proc readDestination*(datagram: Datagram): ConnectionId =
-  ConnectionId(datagram[datagram.findDestination()])
-
-proc findSource(datagram: Datagram): Slice[int] =
-  let destinationEnd = datagram.findDestination().b + 1
-  let start = destinationEnd + 1
-  let length = datagram[destinationEnd].int
-  start..<start+length
-
-proc readSource(datagram: Datagram): ConnectionId =
-  ConnectionId(datagram[datagram.findSource()])
-
-proc findSupportedVersion(datagram: Datagram): Slice[int] =
-  let start = datagram.findSource().b + 1
-  start..<start+4
-
-proc readSupportedVersion*(datagram: Datagram): uint32 =
-  let versionBytes = datagram[datagram.findSupportedVersion()]
-  fromBytesBE(uint32, versionBytes)
 
 proc readVersionNegotiation(datagram: Datagram): Packet =
   Packet(
@@ -162,16 +49,3 @@ proc write*(datagram: var Datagram, header: Packet) =
   if header.form == formLong:
     datagram.writeKind(header)
     datagram.writeVersion(header)
-
-proc `$`*(id: ConnectionId): string =
-  "0x" & cast[string](id).toHex
-
-proc `==`*(x: ConnectionId, y: ConnectionId): bool {.borrow.}
-proc `len`*(x: ConnectionId): int {.borrow.}
-
-proc packetLength*(header: Packet): int =
-  case header.kind:
-  of packetVersionNegotiation:
-    return 11 + header.destination.len + header.source.len
-  else:
-    return 0

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -123,7 +123,7 @@ proc readSupportedVersion*(datagram: seq[byte]): uint32 =
   result.bytes[2] = versionBytes[2]
   result.bytes[3] = versionBytes[3]
 
-proc newVersionNegotiation(datagram: seq[byte]): Packet =
+proc readVersionNegotiation(datagram: seq[byte]): Packet =
   result = Packet(
     form: formLong,
     kind: packetVersionNegotiation,
@@ -134,11 +134,11 @@ proc newVersionNegotiation(datagram: seq[byte]): Packet =
     )
   )
 
-proc newLongPacket(datagram: seq[byte]): Packet =
+proc readLongPacket(datagram: seq[byte]): Packet =
   let kind = datagram.readKind()
   case kind
   of packetVersionNegotiation:
-    result = newVersionNegotiation(datagram)
+    result = readVersionNegotiation(datagram)
   else:
     result = Packet(
       form: formLong,
@@ -148,14 +148,14 @@ proc newLongPacket(datagram: seq[byte]): Packet =
     )
     result.version = datagram.readVersion()
 
-proc newPacket*(datagram: seq[byte]): Packet =
+proc readPacket*(datagram: seq[byte]): Packet =
   let form = datagram.readForm()
   datagram.readFixedBit()
   case form
   of formShort:
     result = Packet(form: form)
   else:
-    result = newLongPacket(datagram)
+    result = readLongPacket(datagram)
 
 proc newShortPacket*(): Packet =
   Packet(form: formShort)

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -14,15 +14,15 @@ type
     packetHandshake
     packetRetry
     packetVersionNegotiation
-  FieldsInitial* = object
+  HeaderInitial* = object
     version*: uint32
-  Fields0RTT* = object
+  Header0RTT* = object
     version*: uint32
-  FieldsHandshake* = object
+  HeaderHandshake* = object
     version*: uint32
-  FieldsRetry* = object
+  HeaderRetry* = object
     version*: uint32
-  FieldsVersionNegotiation* = object
+  HeaderVersionNegotiation* = object
     supportedVersion*: uint32
   Packet* = object
     case form*: PacketForm
@@ -30,11 +30,11 @@ type
       discard
     of formLong:
       case kind*: PacketKind
-      of packetInitial: initial*: FieldsInitial
-      of packet0RTT: rtt*: Fields0RTT
-      of packetHandshake: handshake*: FieldsHandshake
-      of packetRetry: retry*: FieldsRetry
-      of packetVersionNegotiation: negotiation*: FieldsVersionNegotiation
+      of packetInitial: initial*: HeaderInitial
+      of packet0RTT: rtt*: Header0RTT
+      of packetHandshake: handshake*: HeaderHandshake
+      of packetRetry: retry*: HeaderRetry
+      of packetVersionNegotiation: negotiation*: HeaderVersionNegotiation
       destination*: ConnectionId
       source*: ConnectionId
     bytes: seq[byte]
@@ -138,7 +138,7 @@ proc newPacket*(datagram: seq[byte]): Packet =
     case kind
     of packetVersionNegotiation:
       let supportedVersion = datagram.readSupportedVersion()
-      result = Packet(form: form, kind: kind, destination: destination, source: source, negotiation: FieldsVersionNegotiation(supportedVersion: supportedVersion), bytes: datagram)
+      result = Packet(form: form, kind: kind, destination: destination, source: source, negotiation: HeaderVersionNegotiation(supportedVersion: supportedVersion), bytes: datagram)
     else:
       result = Packet(form: form, kind:kind, destination: destination, source: source, bytes: datagram)
       result.version = datagram.readVersion()

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -46,7 +46,7 @@ proc writeForm(datagram: var Datagram, header: Packet) =
   datagram[0].bits[0] = Bit(header.form)
 
 proc readFixedBit(datagram: Datagram) =
-  assert datagram[0].bits[1] == 1
+  doAssert datagram[0].bits[1] == 1
 
 proc writeFixedBit(datagram: var Datagram) =
   datagram[0].bits[1] = 1

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -88,9 +88,19 @@ proc `$`*(header: PacketHeader): string =
 
 proc `==`*(x: ConnectionId, y: ConnectionId): bool {.borrow.}
 
+proc supportedVersionSlice(header: PacketHeader): Slice[int] =
+  let start = header.sourceSlice().b + 1
+  result = start..<start+4
+
+proc supportedVersion*(header: PacketHeader): uint32 =
+  let versionBytes = header.bytes[header.supportedVersionSlice]
+  result.bytes[0] = versionBytes[0]
+  result.bytes[1] = versionBytes[1]
+  result.bytes[2] = versionBytes[2]
+  result.bytes[3] = versionBytes[3]
 proc packetLength*(header: PacketHeader): int =
   case header.kind:
   of packetVersionNegotiation:
-    return header.sourceSlice.b + 1 + 4
+    return header.supportedVersionSlice.b + 1
   else:
     return 0

--- a/quic/packets/connectionid.nim
+++ b/quic/packets/connectionid.nim
@@ -1,0 +1,9 @@
+import strutils
+
+type ConnectionId* = distinct seq[byte]
+
+proc `==`*(x: ConnectionId, y: ConnectionId): bool {.borrow.}
+proc `len`*(x: ConnectionId): int {.borrow.}
+
+proc `$`*(id: ConnectionId): string =
+  "0x" & cast[string](id).toHex

--- a/quic/packets/datagram.nim
+++ b/quic/packets/datagram.nim
@@ -1,0 +1,1 @@
+type Datagram* = openArray[byte]

--- a/quic/packets/length.nim
+++ b/quic/packets/length.nim
@@ -1,0 +1,10 @@
+import packet
+
+{.push raises:[].} # avoid exceptions in this module
+
+proc packetLength*(header: Packet): int =
+  case header.kind:
+  of packetVersionNegotiation:
+    return 11 + header.destination.len + header.source.len
+  else:
+    return 0

--- a/quic/packets/length.nim
+++ b/quic/packets/length.nim
@@ -2,9 +2,9 @@ import packet
 
 {.push raises:[].} # avoid exceptions in this module
 
-proc packetLength*(header: Packet): int =
-  case header.kind:
+proc packetLength*(packet: Packet): int =
+  case packet.kind:
   of packetVersionNegotiation:
-    return 11 + header.destination.len + header.source.len
+    return 11 + packet.destination.len + packet.source.len
   else:
     return 0

--- a/quic/packets/packet.nim
+++ b/quic/packets/packet.nim
@@ -39,18 +39,18 @@ type
       source*: ConnectionId
   PacketNumber* = range[0'u64..2'u64^62-1]
 
-proc version*(header: Packet): uint32 =
-  case header.kind
-  of packetInitial: header.initial.version
-  of packet0RTT: header.rtt.version
-  of packetHandshake: header.handshake.version
-  of packetRetry: header.retry.version
+proc version*(packet: Packet): uint32 =
+  case packet.kind
+  of packetInitial: packet.initial.version
+  of packet0RTT: packet.rtt.version
+  of packetHandshake: packet.handshake.version
+  of packetRetry: packet.retry.version
   of packetVersionNegotiation: 0
 
-proc `version=`*(header: var Packet, version: uint32) =
-  case header.kind
-  of packetInitial: header.initial.version = version
-  of packet0RTT: header.rtt.version = version
-  of packetHandshake: header.handshake.version = version
-  of packetRetry: header.retry.version = version
+proc `version=`*(packet: var Packet, version: uint32) =
+  case packet.kind
+  of packetInitial: packet.initial.version = version
+  of packet0RTT: packet.rtt.version = version
+  of packetHandshake: packet.handshake.version = version
+  of packetRetry: packet.retry.version = version
   of packetVersionNegotiation: discard

--- a/quic/packets/packet.nim
+++ b/quic/packets/packet.nim
@@ -1,0 +1,56 @@
+import math
+import connectionid
+export connectionid
+
+{.push raises:[].} # avoid exceptions in this module
+
+type
+  PacketForm* = enum
+    formShort
+    formLong
+  PacketKind* = enum
+    packetInitial
+    packet0RTT
+    packetHandshake
+    packetRetry
+    packetVersionNegotiation
+  HeaderInitial* = object
+    version*: uint32
+  Header0RTT* = object
+    version*: uint32
+  HeaderHandshake* = object
+    version*: uint32
+  HeaderRetry* = object
+    version*: uint32
+  HeaderVersionNegotiation* = object
+    supportedVersion*: uint32
+  Packet* = object
+    case form*: PacketForm
+    of formShort:
+      discard
+    of formLong:
+      case kind*: PacketKind
+      of packetInitial: initial*: HeaderInitial
+      of packet0RTT: rtt*: Header0RTT
+      of packetHandshake: handshake*: HeaderHandshake
+      of packetRetry: retry*: HeaderRetry
+      of packetVersionNegotiation: negotiation*: HeaderVersionNegotiation
+      destination*: ConnectionId
+      source*: ConnectionId
+  PacketNumber* = range[0'u64..2'u64^62-1]
+
+proc version*(header: Packet): uint32 =
+  case header.kind
+  of packetInitial: header.initial.version
+  of packet0RTT: header.rtt.version
+  of packetHandshake: header.handshake.version
+  of packetRetry: header.retry.version
+  of packetVersionNegotiation: 0
+
+proc `version=`*(header: var Packet, version: uint32) =
+  case header.kind
+  of packetInitial: header.initial.version = version
+  of packet0RTT: header.rtt.version = version
+  of packetHandshake: header.handshake.version = version
+  of packetRetry: header.retry.version = version
+  of packetVersionNegotiation: discard

--- a/quic/packets/read.nim
+++ b/quic/packets/read.nim
@@ -1,0 +1,49 @@
+import stew/endians2
+import ../bits
+import datagram
+import packet
+
+{.push raises:[].} # avoid exceptions in this module
+
+proc readForm*(datagram: Datagram): PacketForm =
+  PacketForm(datagram[0].bits[0])
+
+proc readFixedBit*(datagram: Datagram) =
+  doAssert datagram[0].bits[1] == 1
+
+proc readVersion*(datagram: Datagram): uint32 =
+  fromBytesBE(uint32, datagram[1..4])
+
+proc readKind*(datagram: Datagram): PacketKind =
+  if datagram.readVersion() == 0:
+    packetVersionNegotiation
+  else:
+    var kind: uint8
+    kind.bits[6] = datagram[0].bits[2]
+    kind.bits[7] = datagram[0].bits[3]
+    PacketKind(kind)
+
+proc findDestination(datagram: Datagram): Slice[int] =
+  let start = 6
+  let length = datagram[5].int
+  start..<start+length
+
+proc findSource(datagram: Datagram): Slice[int] =
+  let destinationEnd = datagram.findDestination().b + 1
+  let start = destinationEnd + 1
+  let length = datagram[destinationEnd].int
+  start..<start+length
+
+proc findSupportedVersion(datagram: Datagram): Slice[int] =
+  let start = datagram.findSource().b + 1
+  start..<start+4
+
+proc readDestination*(datagram: Datagram): ConnectionId =
+  ConnectionId(datagram[datagram.findDestination()])
+
+proc readSource*(datagram: Datagram): ConnectionId =
+  ConnectionId(datagram[datagram.findSource()])
+
+proc readSupportedVersion*(datagram: Datagram): uint32 =
+  let versionBytes = datagram[datagram.findSupportedVersion()]
+  fromBytesBE(uint32, versionBytes)

--- a/quic/packets/write.nim
+++ b/quic/packets/write.nim
@@ -1,0 +1,25 @@
+import stew/endians2
+import datagram
+import packet
+import ../bits
+
+proc writeForm*(datagram: var Datagram, header: Packet) =
+  datagram[0].bits[0] = Bit(header.form)
+
+proc writeFixedBit*(datagram: var Datagram) =
+  datagram[0].bits[1] = 1
+
+proc writeKind*(datagram: var Datagram, header: Packet) =
+  case header.kind:
+  of packetVersionNegotiation:
+    discard
+  else:
+    datagram[0].bits[2] = header.kind.uint8.bits[6]
+    datagram[0].bits[3] = header.kind.uint8.bits[7]
+
+proc writeVersion*(datagram: var Datagram, header: Packet) =
+  let bytes = toBytesBE(header.version)
+  datagram[1] = bytes[0]
+  datagram[2] = bytes[1]
+  datagram[3] = bytes[2]
+  datagram[4] = bytes[3]

--- a/quic/packets/write.nim
+++ b/quic/packets/write.nim
@@ -3,22 +3,22 @@ import datagram
 import packet
 import ../bits
 
-proc writeForm*(datagram: var Datagram, header: Packet) =
-  datagram[0].bits[0] = Bit(header.form)
+proc writeForm*(datagram: var Datagram, packet: Packet) =
+  datagram[0].bits[0] = Bit(packet.form)
 
 proc writeFixedBit*(datagram: var Datagram) =
   datagram[0].bits[1] = 1
 
-proc writeKind*(datagram: var Datagram, header: Packet) =
-  case header.kind:
+proc writeKind*(datagram: var Datagram, packet: Packet) =
+  case packet.kind:
   of packetVersionNegotiation:
     discard
   else:
-    datagram[0].bits[2] = header.kind.uint8.bits[6]
-    datagram[0].bits[3] = header.kind.uint8.bits[7]
+    datagram[0].bits[2] = packet.kind.uint8.bits[6]
+    datagram[0].bits[3] = packet.kind.uint8.bits[7]
 
-proc writeVersion*(datagram: var Datagram, header: Packet) =
-  let bytes = toBytesBE(header.version)
+proc writeVersion*(datagram: var Datagram, packet: Packet) =
+  let bytes = toBytesBE(packet.version)
   datagram[1] = bytes[0]
   datagram[2] = bytes[1]
   datagram[3] = bytes[2]

--- a/tests/quic/testBits.nim
+++ b/tests/quic/testBits.nim
@@ -27,19 +27,3 @@ suite "bits":
     value.bits[3] = 0
     value.bits[7] = 0
     check value == 0b01101110'u8
-
-suite "bytes":
-
-  test "can index bytes":
-    let value = 0xAABBCCDD'u32
-    check value.bytes[0] == 0xAA
-    check value.bytes[1] == 0xBB
-    check value.bytes[2] == 0xCC
-    check value.bytes[3] == 0xDD
-
-  test "can set bytes":
-    var value = 0x00000000'u32
-    value.bytes[0] = 0xAA
-    value.bytes[2] = 0xCC
-    value.bytes[3] = 0xDD
-    check value == 0xAA00CCDD'u32

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -36,9 +36,6 @@ suite "short headers":
     datagram.write(newShortPacket())
     check datagram[0].bits[1] == 1
 
-  test "conversion to string":
-    check $newPacket(@[0b01000000'u8]) == "(form: formShort)"
-
 suite "long headers":
 
   var datagram: seq[byte]
@@ -110,19 +107,6 @@ suite "long headers":
     )
     check header.source == ConnectionId(source)
 
-  test "conversion to string":
-    let header = $newPacket(
-      type0 &
-      version1 &
-      destination.len.uint8 & destination &
-      source.len.uint8 & source
-    )
-    check $header == "(" &
-      "kind: packetInitial, " &
-      "destination: 0xAABBCC, " &
-      "source: 0xDDEEFF" &
-    ")"
-
   suite "version negotiation packet":
 
     test "has a fixed length":
@@ -150,22 +134,6 @@ suite "long headers":
         version1
       )
       check header.negotiation.supportedVersion == 1'u32
-
-    test "conversion to string":
-      let header = newPacket(
-        type0 &
-        version0 &
-        destination.len.uint8 & destination &
-        source.len.uint8 & source &
-        version1
-      )
-      check $header == "(" &
-        "kind: packetVersionNegotiation, " &
-        "destination: 0xAABBCC, " &
-        "source: 0xDDEEFF, " &
-        "supportedVersion: 1" &
-      ")"
-
 
 suite "packet numbers":
 

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -32,6 +32,10 @@ suite "short headers":
     datagram.write(newShortPacketHeader())
     check datagram[0].bits[0] == 0
 
+  test "writes correct fixed bit":
+    datagram.write(newShortPacketHeader())
+    check datagram[0].bits[1] == 1
+
   test "conversion to string":
     check $newPacketHeader(@[0b01000000'u8]) == "(kind: packetShort)"
 

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -5,14 +5,12 @@ import quic/bits
 
 suite "packet header":
 
-  test "first bit of the header indicates its form":
-    check newPacketHeader(@[0b01000000'u8]).form == headerShort
-    check newPacketHeader(@[0b11000000'u8]).form == headerLong
-
-  test "header form can be set":
-    var header = newPacketHeader(@[0b01000000'u8])
-    header.form = headerLong
-    check header.bytes[0].bits[0] == 1
+  test "first bit of the header indicates short/long form":
+    var datagram = newSeq[byte](4096)
+    datagram[0] = 0b01000000'u8
+    check newPacketHeader(datagram).kind == packetShort
+    datagram[0] = 0b11000000'u8
+    check newPacketHeader(datagram).kind != packetShort
 
   test "second bit of the header should always be 1":
     expect Exception:
@@ -21,7 +19,7 @@ suite "packet header":
 suite "short headers":
 
   test "conversion to string":
-    check $newPacketHeader(@[0b01000000'u8]) == "(form: headerShort)"
+    check $newPacketHeader(@[0b01000000'u8]) == "(kind: packetShort)"
 
 suite "long headers":
 
@@ -97,7 +95,6 @@ suite "long headers":
       source.len.uint8 & source
     )
     check $header == "(" &
-      "form: headerLong, " &
       "kind: packetInitial, " &
       "destination: 0xAABBCC, " &
       "source: 0xDDEEFF" &
@@ -140,7 +137,6 @@ suite "long headers":
         version1
       )
       check $header == "(" &
-        "form: headerLong, " &
         "kind: packetVersionNegotiation, " &
         "destination: 0xAABBCC, " &
         "source: 0xDDEEFF, " &

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -5,16 +5,21 @@ import quic/bits
 
 suite "packet header":
 
+  var datagram: seq[byte]
+
+  setup:
+    datagram = newSeq[byte](4096)
+
   test "first bit of the header indicates short/long form":
-    var datagram = newSeq[byte](4096)
     datagram[0] = 0b01000000'u8
     check newPacketHeader(datagram).kind == packetShort
     datagram[0] = 0b11000000'u8
     check newPacketHeader(datagram).kind != packetShort
 
   test "second bit of the header should always be 1":
+    datagram[0] = 0b00000000'u8
     expect Exception:
-      discard newPacketHeader(@[0b00000000'u8])
+      discard newPacketHeader(datagram)
 
 suite "short headers":
 

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -55,63 +55,63 @@ suite "long headers":
 
   test "QUIC version is stored in bytes 1..4":
     var version = 0xAABBCCDD'u32
-    var header = readPacket(
+    var packet = readPacket(
       type0 &
       @(toBytesBE(version)) &
       destination.len.uint8 & destination &
       source.len.uint8 & source
     )
-    check header.version == version
+    check packet.version == version
 
   test "QUIC version can be set":
-    var header = Packet(form: formLong, kind: packetInitial)
-    header.version = 0xAABBCCDD'u32
-    datagram.write(header)
+    var packet = Packet(form: formLong, kind: packetInitial)
+    packet.version = 0xAABBCCDD'u32
+    datagram.write(packet)
     check datagram[1..4] == @[0xAA'u8, 0xBB'u8, 0xCC'u8, 0xDD'u8]
 
   test "version negotiation packet is a packet with version 0":
-    let header = readPacket(type0 & version0 & destination.len.uint8 & destination & source.len.uint8 & source & version1)
-    check header.kind == packetVersionNegotiation
+    let packet = readPacket(type0 & version0 & destination.len.uint8 & destination & source.len.uint8 & source & version1)
+    check packet.kind == packetVersionNegotiation
 
   test "initial packet is a long packet of type 0":
-    let header = readPacket(type0 & version1 & destination.len.uint8 & destination & source.len.uint8 & source)
-    check header.kind == packetInitial
+    let packet = readPacket(type0 & version1 & destination.len.uint8 & destination & source.len.uint8 & source)
+    check packet.kind == packetInitial
 
   test "0-RTT packet is a long packet of type 1":
-    let header = readPacket(type1 & version1 & destination.len.uint8 & destination & source.len.uint8 & source)
-    check header.kind == packet0RTT
+    let packet = readPacket(type1 & version1 & destination.len.uint8 & destination & source.len.uint8 & source)
+    check packet.kind == packet0RTT
 
   test "handshake packet is a long packet of type 2":
-    let header = readPacket(type2 & version1 & destination.len.uint8 & destination & source.len.uint8 & source)
-    check header.kind == packetHandshake
+    let packet = readPacket(type2 & version1 & destination.len.uint8 & destination & source.len.uint8 & source)
+    check packet.kind == packetHandshake
 
   test "retry packet is a long packet of type 3":
-    let header = readPacket(type3 & version1 & destination.len.uint8 & destination & source.len.uint8 & source)
-    check header.kind == packetRetry
+    let packet = readPacket(type3 & version1 & destination.len.uint8 & destination & source.len.uint8 & source)
+    check packet.kind == packetRetry
 
   test "long packet type can be set":
-    var header = Packet(form: formLong, kind: packetHandshake)
-    datagram.write(header)
+    var packet = Packet(form: formLong, kind: packetHandshake)
+    datagram.write(packet)
     check datagram[0].bits[2] == 1
     check datagram[0].bits[3] == 0
 
   test "destination connection id is encoded from byte 5 onwards":
     let id = @[1'u8, 2'u8, 3'u8]
-    var header = readPacket(type0 & version1 & id.len.uint8 & id & source.len.uint8 & source)
-    check header.destination == ConnectionId(id)
+    var packet = readPacket(type0 & version1 & id.len.uint8 & id & source.len.uint8 & source)
+    check packet.destination == ConnectionId(id)
 
   test "source connection id follows the destination connection id":
-    var header = readPacket(
+    var packet = readPacket(
       type0 & version1 &
       destination.len.uint8 & destination &
       source.len.uint8 & source
     )
-    check header.source == ConnectionId(source)
+    check packet.source == ConnectionId(source)
 
   suite "version negotiation packet":
 
     test "has a fixed length":
-      let header = readPacket(
+      let packet = readPacket(
         type0 &
         version0 &
         destination.len.uint8 & destination &
@@ -119,7 +119,7 @@ suite "long headers":
         version1 &
         @[byte('r'), byte('e'), byte('s'), byte('t')]
       )
-      check header.packetLength ==
+      check packet.packetLength ==
         type0.len +
         version0.len +
         destination.len + 1 +
@@ -127,14 +127,14 @@ suite "long headers":
         version1.len
 
     test "has a supported version field":
-      let header = readPacket(
+      let packet = readPacket(
         type0 &
         version0 &
         destination.len.uint8 & destination &
         source.len.uint8 & source &
         version1
       )
-      check header.negotiation.supportedVersion == 1'u32
+      check packet.negotiation.supportedVersion == 1'u32
 
 suite "packet numbers":
 

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -28,6 +28,11 @@ suite "short headers":
 
 suite "long headers":
 
+  var datagram: seq[byte]
+
+  setup:
+    datagram = newSeq[byte](4096)
+
   const type0 = @[0b11000000'u8]
   const type1 = @[0b11010000'u8]
   const type2 = @[0b11100000'u8]
@@ -51,7 +56,8 @@ suite "long headers":
   test "QUIC version can be set":
     var header = newPacketHeader(@[0b11000000'u8, 0'u8, 0'u8, 0'u8, 0'u8])
     header.version = 0xAABBCCDD'u32
-    check header.bytes[1..4] == @[0xAA'u8, 0xBB'u8, 0xCC'u8, 0xDD'u8]
+    datagram.write(header)
+    check datagram[1..4] == @[0xAA'u8, 0xBB'u8, 0xCC'u8, 0xDD'u8]
 
   test "version negotiation packet is a packet with version 0":
     let header = newPacketHeader(type0 & version0)
@@ -76,8 +82,9 @@ suite "long headers":
   test "long packet type can be set":
     var header = newPacketHeader(type0 & version1)
     header.kind = packetHandshake
-    check header.bytes[0].bits[2] == 1
-    check header.bytes[0].bits[3] == 0
+    datagram.write(header)
+    check datagram[0].bits[2] == 1
+    check datagram[0].bits[3] == 0
 
   test "destination connection id is encoded from byte 5 onwards":
     let id = @[1'u8, 2'u8, 3'u8]

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -92,8 +92,7 @@ suite "long headers":
     check header.kind == packetRetry
 
   test "long packet type can be set":
-    var header = newPacketHeader(type0 & version1 & destination.len.uint8 & destination & source.len.uint8 & source)
-    header.kind = packetHandshake
+    var header = PacketHeader(form: formLong, kind: packetHandshake)
     datagram.write(header)
     check datagram[0].bits[2] == 1
     check datagram[0].bits[3] == 0
@@ -150,7 +149,7 @@ suite "long headers":
         source.len.uint8 & source &
         version1
       )
-      check header.supportedVersion == 1'u32
+      check header.negotiation.supportedVersion == 1'u32
 
     test "conversion to string":
       let header = newPacketHeader(

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -72,7 +72,7 @@ suite "long headers":
     check datagram[1..4] == @[0xAA'u8, 0xBB'u8, 0xCC'u8, 0xDD'u8]
 
   test "version negotiation packet is a packet with version 0":
-    let header = newPacketHeader(type0 & version0 & destination.len.uint8 & destination & source.len.uint8 & source)
+    let header = newPacketHeader(type0 & version0 & destination.len.uint8 & destination & source.len.uint8 & source & version1)
     check header.kind == packetVersionNegotiation
 
   test "initial packet is a long packet of type 0":

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -92,13 +92,13 @@ suite "long headers":
   test "conversion to string":
     let header = $newPacketHeader(
       type0 &
-      version0 &
+      version1 &
       destination.len.uint8 & destination &
       source.len.uint8 & source
     )
     check $header == "(" &
       "form: headerLong, " &
-      "kind: packetVersionNegotiation, " &
+      "kind: packetInitial, " &
       "destination: 0xAABBCC, " &
       "source: 0xDDEEFF" &
     ")"
@@ -130,6 +130,23 @@ suite "long headers":
         version1
       )
       check header.supportedVersion == 1'u32
+
+    test "conversion to string":
+      let header = newPacketHeader(
+        type0 &
+        version0 &
+        destination.len.uint8 & destination &
+        source.len.uint8 & source &
+        version1
+      )
+      check $header == "(" &
+        "form: headerLong, " &
+        "kind: packetVersionNegotiation, " &
+        "destination: 0xAABBCC, " &
+        "source: 0xDDEEFF, " &
+        "supportedVersion: 1" &
+      ")"
+
 
 suite "packet numbers":
 

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -66,7 +66,7 @@ suite "long headers":
     check header.version == version
 
   test "QUIC version can be set":
-    var header = PacketHeader(form: formLong, kind: packetInitial, version: 1)
+    var header = PacketHeader(form: formLong, kind: packetInitial)
     header.version = 0xAABBCCDD'u32
     datagram.write(header)
     check datagram[1..4] == @[0xAA'u8, 0xBB'u8, 0xCC'u8, 0xDD'u8]

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -2,6 +2,7 @@ import unittest
 import math
 import quic
 import quic/bits
+import stew/endians2
 
 suite "packet header":
 
@@ -56,7 +57,7 @@ suite "long headers":
     var version = 0xAABBCCDD'u32
     var header = readPacket(
       type0 &
-      @[version.bytes[0], version.bytes[1], version.bytes[2],  version.bytes[3]] &
+      @(toBytesBE(version)) &
       destination.len.uint8 & destination &
       source.len.uint8 & source
     )

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -121,6 +121,16 @@ suite "long headers":
         source.len + 1 +
         version1.len
 
+    test "has a supported version field":
+      let header = newPacketHeader(
+        type0 &
+        version0 &
+        destination.len.uint8 & destination &
+        source.len.uint8 & source &
+        version1
+      )
+      check header.supportedVersion == 1'u32
+
 suite "packet numbers":
 
   test "packet numbers are in the range 0 to 2^62-1":

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -23,6 +23,15 @@ suite "packet header":
 
 suite "short headers":
 
+  var datagram: seq[byte]
+
+  setup:
+    datagram = newSeq[byte](4096)
+
+  test "writes correct form bit":
+    datagram.write(newShortPacketHeader())
+    check datagram[0].bits[0] == 0
+
   test "conversion to string":
     check $newPacketHeader(@[0b01000000'u8]) == "(kind: packetShort)"
 
@@ -54,7 +63,7 @@ suite "long headers":
     check header.version == version
 
   test "QUIC version can be set":
-    var header = newPacketHeader(@[0b11000000'u8, 0'u8, 0'u8, 0'u8, 0'u8])
+    var header = newPacketHeader(@[0b11000000'u8, 0'u8, 0'u8, 0'u8, 1'u8])
     header.version = 0xAABBCCDD'u32
     datagram.write(header)
     check datagram[1..4] == @[0xAA'u8, 0xBB'u8, 0xCC'u8, 0xDD'u8]

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -12,9 +12,9 @@ suite "packet header":
 
   test "first bit of the header indicates short/long form":
     datagram[0] = 0b01000000'u8
-    check newPacketHeader(datagram).kind == packetShort
+    check newPacketHeader(datagram).form == formShort
     datagram[0] = 0b11000000'u8
-    check newPacketHeader(datagram).kind != packetShort
+    check newPacketHeader(datagram).form == formLong
 
   test "second bit of the header should always be 1":
     datagram[0] = 0b00000000'u8
@@ -37,7 +37,7 @@ suite "short headers":
     check datagram[0].bits[1] == 1
 
   test "conversion to string":
-    check $newPacketHeader(@[0b01000000'u8]) == "(kind: packetShort)"
+    check $newPacketHeader(@[0b01000000'u8]) == "(form: formShort)"
 
 suite "long headers":
 

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -103,6 +103,24 @@ suite "long headers":
       "source: 0xDDEEFF" &
     ")"
 
+  suite "version negotiation packet":
+
+    test "has a fixed length":
+      let header = newPacketHeader(
+        type0 &
+        version0 &
+        destination.len.uint8 & destination &
+        source.len.uint8 & source &
+        version1 &
+        @[byte('r'), byte('e'), byte('s'), byte('t')]
+      )
+      check header.packetLength ==
+        type0.len +
+        version0.len +
+        destination.len + 1 +
+        source.len + 1 +
+        version1.len
+
 suite "packet numbers":
 
   test "packet numbers are in the range 0 to 2^62-1":

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -18,22 +18,6 @@ suite "packet header":
     expect Exception:
       discard newPacketHeader(@[0b00000000'u8])
 
-  test "QUIC version is stored in bytes 1..4":
-    var version = 0xAABBCCDD'u32
-    var header = newPacketHeader(@[
-      0b01000000'u8,
-      version.bytes[0],
-      version.bytes[1],
-      version.bytes[2],
-      version.bytes[3]
-    ])
-    check header.version == version
-
-  test "QUIC version can be set":
-    var header = newPacketHeader(@[0b01000000'u8, 0'u8, 0'u8, 0'u8, 0'u8])
-    header.version = 0xAABBCCDD'u32
-    check header.bytes[1..4] == @[0xAA'u8, 0xBB'u8, 0xCC'u8, 0xDD'u8]
-
 suite "short headers":
 
   test "conversion to string":
@@ -49,6 +33,22 @@ suite "long headers":
   const version1 = @[0'u8, 0'u8, 0'u8, 1'u8]
   const destination = @[0xAA'u8, 0xBB'u8, 0xCC'u8]
   const source = @[0xDD'u8, 0xEE'u8, 0xFF'u8]
+
+  test "QUIC version is stored in bytes 1..4":
+    var version = 0xAABBCCDD'u32
+    var header = newPacketHeader(@[
+      0b11000000'u8,
+      version.bytes[0],
+      version.bytes[1],
+      version.bytes[2],
+      version.bytes[3]
+    ])
+    check header.version == version
+
+  test "QUIC version can be set":
+    var header = newPacketHeader(@[0b11000000'u8, 0'u8, 0'u8, 0'u8, 0'u8])
+    header.version = 0xAABBCCDD'u32
+    check header.bytes[1..4] == @[0xAA'u8, 0xBB'u8, 0xCC'u8, 0xDD'u8]
 
   test "version negotiation packet is a packet with version 0":
     let header = newPacketHeader(type0 & version0)

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -29,11 +29,11 @@ suite "short headers":
     datagram = newSeq[byte](4096)
 
   test "writes correct form bit":
-    datagram.write(newShortPacket())
+    datagram.write(Packet(form: formShort))
     check datagram[0].bits[0] == 0
 
   test "writes correct fixed bit":
-    datagram.write(newShortPacket())
+    datagram.write(Packet(form: formShort))
     check datagram[0].bits[1] == 1
 
 suite "long headers":

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -57,43 +57,42 @@ suite "long headers":
 
   test "QUIC version is stored in bytes 1..4":
     var version = 0xAABBCCDD'u32
-    var header = newPacketHeader(@[
-      0b11000000'u8,
-      version.bytes[0],
-      version.bytes[1],
-      version.bytes[2],
-      version.bytes[3]
-    ])
+    var header = newPacketHeader(
+      type0 &
+      @[version.bytes[0], version.bytes[1], version.bytes[2],  version.bytes[3]] &
+      destination.len.uint8 & destination &
+      source.len.uint8 & source
+    )
     check header.version == version
 
   test "QUIC version can be set":
-    var header = newPacketHeader(@[0b11000000'u8, 0'u8, 0'u8, 0'u8, 1'u8])
+    var header = PacketHeader(form: formLong, kind: packetInitial, version: 1)
     header.version = 0xAABBCCDD'u32
     datagram.write(header)
     check datagram[1..4] == @[0xAA'u8, 0xBB'u8, 0xCC'u8, 0xDD'u8]
 
   test "version negotiation packet is a packet with version 0":
-    let header = newPacketHeader(type0 & version0)
+    let header = newPacketHeader(type0 & version0 & destination.len.uint8 & destination & source.len.uint8 & source)
     check header.kind == packetVersionNegotiation
 
   test "initial packet is a long packet of type 0":
-    let header = newPacketHeader(type0 & version1)
+    let header = newPacketHeader(type0 & version1 & destination.len.uint8 & destination & source.len.uint8 & source)
     check header.kind == packetInitial
 
   test "0-RTT packet is a long packet of type 1":
-    let header = newPacketHeader(type1 & version1)
+    let header = newPacketHeader(type1 & version1 & destination.len.uint8 & destination & source.len.uint8 & source)
     check header.kind == packet0RTT
 
   test "handshake packet is a long packet of type 2":
-    let header = newPacketHeader(type2 & version1)
+    let header = newPacketHeader(type2 & version1 & destination.len.uint8 & destination & source.len.uint8 & source)
     check header.kind == packetHandshake
 
   test "retry packet is a long packet of type 3":
-    let header = newPacketHeader(type3 & version1)
+    let header = newPacketHeader(type3 & version1 & destination.len.uint8 & destination & source.len.uint8 & source)
     check header.kind == packetRetry
 
   test "long packet type can be set":
-    var header = newPacketHeader(type0 & version1)
+    var header = newPacketHeader(type0 & version1 & destination.len.uint8 & destination & source.len.uint8 & source)
     header.kind = packetHandshake
     datagram.write(header)
     check datagram[0].bits[2] == 1
@@ -101,7 +100,7 @@ suite "long headers":
 
   test "destination connection id is encoded from byte 5 onwards":
     let id = @[1'u8, 2'u8, 3'u8]
-    var header = newPacketHeader(type0 & version1 & id.len.uint8 & id)
+    var header = newPacketHeader(type0 & version1 & id.len.uint8 & id & source.len.uint8 & source)
     check header.destination == ConnectionId(id)
 
   test "source connection id follows the destination connection id":


### PR DESCRIPTION
Converts Packet struct to use object variants.
Adds version negotiation fields and length.