### PR TITLE
Fix: packet length includes both packet number and payload

### DIFF
--- a/quic.nim
+++ b/quic.nim
@@ -1,2 +1,4 @@
+import quic/version
 import quic/packets
+export version
 export packets

--- a/quic/packets.nim
+++ b/quic/packets.nim
@@ -16,8 +16,7 @@ proc read(reader: var PacketReader, datagram: Datagram): Packet =
     reader.readSpinBit(datagram)
     reader.readKeyPhase(datagram)
     reader.readShortDestination(datagram)
-    reader.readPacketNumber(datagram)
-    reader.readShortPayload(datagram)
+    reader.readPacketNumberAndPayload(datagram)
   of formLong:
     reader.readKind(datagram)
     reader.readVersion(datagram)
@@ -30,14 +29,10 @@ proc read(reader: var PacketReader, datagram: Datagram): Packet =
       reader.readRetryToken(datagram)
       reader.readIntegrity(datagram)
     of packetHandshake, packet0RTT:
-      let length = reader.readVarInt(datagram)
-      reader.readPacketNumber(datagram)
-      reader.readPayload(datagram, length.int)
+      reader.readPacketNumberAndPayload(datagram)
     of packetInitial:
       reader.readInitialToken(datagram)
-      let length = reader.readVarInt(datagram)
-      reader.readPacketNumber(datagram)
-      reader.readPayload(datagram, length.int)
+      reader.readPacketNumberAndPayload(datagram)
   reader.packet
 
 proc readPacket*(datagram: Datagram): Packet =
@@ -59,8 +54,7 @@ proc write(writer: var PacketWriter, datagram: var Datagram) =
     writer.writeReservedBits(datagram)
     writer.writeKeyPhase(datagram)
     writer.writeShortDestination(datagram)
-    writer.writePacketNumber(datagram)
-    writer.writePayload(datagram)
+    writer.writePacketNumberAndPayload(datagram)
   of formLong:
     writer.writeKind(datagram)
     writer.writeVersion(datagram)
@@ -73,15 +67,11 @@ proc write(writer: var PacketWriter, datagram: var Datagram) =
       writer.writeToken(datagram)
       writer.writeIntegrity(datagram)
     of packetHandshake, packet0RTT:
-      writer.writePacketLength(datagram)
-      writer.writePacketNumber(datagram)
-      writer.writePayload(datagram)
+      writer.writePacketNumberAndPayload(datagram)
     of packetInitial:
       writer.writeTokenLength(datagram)
       writer.writeToken(datagram)
-      writer.writePacketLength(datagram)
-      writer.writePacketNumber(datagram)
-      writer.writePayload(datagram)
+      writer.writePacketNumberAndPayload(datagram)
 
 proc write*(datagram: var Datagram, packet: Packet): int {.discardable.} =
   var writer = PacketWriter(packet: packet)

--- a/quic/packets/packet.nim
+++ b/quic/packets/packet.nim
@@ -1,5 +1,6 @@
 import connectionid
 import packetnumber
+import ../version
 export connectionid
 export PacketNumber
 include ../noerrors
@@ -51,6 +52,29 @@ type
       of packetVersionNegotiation: negotiation*: PacketVersionNegotiation
       source*: ConnectionId
     destination*: ConnectionId
+
+proc shortPacket*: Packet =
+  Packet(form: formShort)
+
+proc initialPacket*(version: uint32 = CurrentQuicVersion): Packet =
+  result = Packet(form: formLong, kind: packetInitial)
+  result.initial.version = version
+
+proc zeroRttPacket*(version: uint32 = CurrentQuicVersion): Packet =
+  result = Packet(form: formLong, kind: packet0RTT)
+  result.rtt.version = version
+
+proc handshakePacket*(version: uint32 = CurrentQuicVersion): Packet =
+  result = Packet(form: formLong, kind: packetHandshake)
+  result.handshake.version = version
+
+proc retryPacket*(version: uint32 = CurrentQuicVersion): Packet =
+  result = Packet(form: formLong, kind: packetRetry)
+  result.retry.version = version
+
+proc versionNegotiationPacket*(version: uint32 = CurrentQuicVersion): Packet =
+  result = Packet(form: formLong, kind: packetVersionNegotiation)
+  result.negotiation.supportedVersion = version
 
 proc `==`*(a, b: Packet): bool =
   if a.form != b.form: return false

--- a/quic/version.nim
+++ b/quic/version.nim
@@ -1,0 +1,2 @@
+const DraftVersion29 = 0xFF00001D'u32
+const CurrentQuicVersion* = DraftVersion29

--- a/tests/quic/testPacketLength.nim
+++ b/tests/quic/testPacketLength.nim
@@ -10,14 +10,14 @@ suite "packet length":
   const token = @[0xA'u8, 0xB'u8, 0xC'u8]
 
   test "knows the length of a version negotiation packet":
-    var packet = Packet(form: formLong, kind: packetVersionNegotiation)
+    var packet = versionNegotiationPacket()
     packet.destination = destination
     packet.source = source
     packet.negotiation.supportedVersion = 42
     check packet.len == 11 + destination.len + source.len
 
   test "knows the length of a retry packet":
-    var packet = Packet(form: formLong, kind: packetRetry)
+    var packet = retryPacket()
     packet.destination = destination
     packet.source = source
     packet.retry.token = token
@@ -25,7 +25,7 @@ suite "packet length":
     check packet.len == 7 + destination.len + source.len + token.len + 16
 
   test "knows the length of a handshake packet":
-    var packet = Packet(form: formLong, kind: packetHandshake)
+    var packet = handshakePacket()
     packet.destination = destination
     packet.source = source
     packet.handshake.packetnumber = 0x00BBCCDD'u32
@@ -38,7 +38,7 @@ suite "packet length":
       1024 # payload
 
   test "knows the length of a 0-RTT packet":
-    var packet = Packet(form: formLong, kind: packet0RTT)
+    var packet = zeroRttPacket()
     packet.destination = destination
     packet.source = source
     packet.rtt.packetnumber = 0x00BBCCDD'u32
@@ -51,7 +51,7 @@ suite "packet length":
       1024 # payload
 
   test "knows the length of an initial packet":
-    var packet = Packet(form: formLong, kind: packetInitial)
+    var packet = initialPacket()
     packet.destination = destination
     packet.source = source
     packet.initial.token = token
@@ -67,7 +67,7 @@ suite "packet length":
       1024 # payload
 
   test "knows the length of a short packet":
-    var packet = Packet(form:formShort)
+    var packet = shortPacket()
     packet.destination = destination
     packet.short.packetnumber = 0x00BBCCDD'u32
     packet.short.payload = repeat(0xEE'u8, 1024)

--- a/tests/quic/testPacketWriting.nim
+++ b/tests/quic/testPacketWriting.nim
@@ -68,6 +68,15 @@ suite "packet writing":
     datagram.write(packet)
     check datagram[packet.len-16..<packet.len] == packet.retry.integrity
 
+  test "writes handshake packet length":
+    const packetnumber = 0xAABBCCDD'u32
+    const payload = repeat(0xAB'u8, 1024)
+    var packet = handshakePacket()
+    packet.handshake.packetnumber = packetnumber
+    packet.handshake.payload = payload
+    datagram.write(packet)
+    check datagram[7..8] == (sizeof(packetnumber) + payload.len).toVarInt
+
   test "writes handshake packet number":
     const packetnumber = 0xAABBCCDD'u32
     var packet = handshakePacket()
@@ -81,8 +90,16 @@ suite "packet writing":
     var packet = handshakePacket()
     packet.handshake.payload = payload
     datagram.write(packet)
-    check datagram[7..8] == payload.len.toVarInt
     check datagram[10..1033] == payload
+
+  test "writes 0-RTT packet length":
+    const packetnumber = 0xAABBCCDD'u32
+    const payload = repeat(0xAB'u8, 1024)
+    var packet = zeroRttPacket()
+    packet.rtt.packetnumber = packetnumber
+    packet.rtt.payload = payload
+    datagram.write(packet)
+    check datagram[7..8] == (sizeof(packetnumber) + payload.len).toVarInt
 
   test "writes 0-RTT packet number":
     const packetnumber = 0xAABBCCDD'u32
@@ -97,7 +114,6 @@ suite "packet writing":
     var packet = zeroRttPacket()
     packet.rtt.payload = payload
     datagram.write(packet)
-    check datagram[7..8] == payload.len.toVarInt
     check datagram[10..1033] == payload
 
   test "writes initial token":
@@ -107,6 +123,15 @@ suite "packet writing":
     datagram.write(packet)
     check datagram[7..8] == token.len.toVarInt
     check datagram[9..1032] == token
+
+  test "writes initial packet length":
+    const packetnumber = 0xAABBCCDD'u32
+    const payload = repeat(0xAB'u8, 1024)
+    var packet = initialPacket()
+    packet.initial.packetnumber = packetnumber
+    packet.initial.payload = payload
+    datagram.write(packet)
+    check datagram[8..9] == (sizeof(packetnumber) + payload.len).toVarInt
 
   test "writes initial packet number":
     const packetnumber = 0xAABBCCDD'u32
@@ -121,7 +146,6 @@ suite "packet writing":
     var packet = initialPacket()
     packet.initial.payload = payload
     datagram.write(packet)
-    check datagram[8..9] == payload.len.toVarInt
     check datagram[11..1034] == payload
 
   test "writes spin bit":

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -44,14 +44,14 @@ suite "multiple packets":
     datagram = newSeq[byte](4096)
 
   test "writes multiple packets into a datagram":
-    let packet1 = Packet(form: formLong, kind: packetInitial)
-    let packet2 = Packet(form: formLong, kind: packetHandshake)
+    let packet1 = initialPacket()
+    let packet2 = handshakePacket()
     datagram.write(@[packet1, packet2])
     check datagram[0] == 0b11_00_0000 # initial
     check datagram[packet1.len] == 0b11_10_0000 # handshake
 
   test "writes packet number lengths correctly":
-    var packet1, packet2 = Packet(form: formLong)
+    var packet1, packet2 = initialPacket()
     packet1.initial.packetnumber = 0xAABBCC
     packet2.initial.packetnumber = 0xAABBCCDD
     datagram.write(@[packet1, packet2])
@@ -59,14 +59,12 @@ suite "multiple packets":
     check datagram[packet1.len] == 0b110000_11 # packet number length 4
 
   test "returns the number of bytes that were written":
-    let packet1 = Packet(form: formLong, kind: packetInitial)
-    let packet2 = Packet(form: formLong, kind: packetHandshake)
+    let packet1 = initialPacket()
+    let packet2 = handshakePacket()
     check datagram.write(@[packet1, packet2]) == packet1.len + packet2.len
 
   test "reads multiple packets from a datagram":
-    var packet1 = Packet(form: formLong, kind: packetInitial)
-    var packet2 = Packet(form: formLong, kind: packetHandshake)
-    packet1.initial.version = 1
-    packet2.handshake.version = 1
+    var packet1 = initialPacket()
+    var packet2 = handshakePacket()
     let length = datagram.write(@[packet1, packet2])
     check datagram[0..<length].readPackets() == @[packet1, packet2]

--- a/tests/quic/testPackets.nim
+++ b/tests/quic/testPackets.nim
@@ -1,6 +1,41 @@
 import unittest
 import quic
 
+suite "packet creation":
+
+  test "short packets":
+    check shortPacket() == Packet(form: formShort)
+
+  test "initial packets":
+    let packet = initialPacket()
+    check packet.form == formLong
+    check packet.kind == packetInitial
+    check packet.initial.version == CurrentQuicVersion
+
+  test "0-RTT packets":
+    let packet = zeroRttPacket()
+    check packet.form == formLong
+    check packet.kind == packet0RTT
+    check packet.rtt.version == CurrentQuicVersion
+
+  test "handshake packets":
+    let packet = handshakePacket()
+    check packet.form == formLong
+    check packet.kind == packetHandshake
+    check packet.handshake.version == CurrentQuicVersion
+
+  test "retry packets":
+    let packet = retryPacket()
+    check packet.form == formLong
+    check packet.kind == packetRetry
+    check packet.retry.version == CurrentQuicVersion
+
+  test "version negotiation packets":
+    let packet = versionNegotiationPacket()
+    check packet.form == formLong
+    check packet.kind == packetVersionNegotiation
+    check packet.negotiation.supportedVersion == CurrentQuicVersion
+
 suite "multiple packets":
 
   var datagram: seq[byte]


### PR DESCRIPTION
Includes changes to testPacketReading that make this fix easier.