### PR TITLE
Drain streams that were closed by peer

### DIFF
--- a/quic/transport/ngtcp2/stream/drainingstate.nim
+++ b/quic/transport/ngtcp2/stream/drainingstate.nim
@@ -1,0 +1,31 @@
+import pkg/chronos
+import ../../stream
+import ./closedstate
+
+type
+  DrainingStream* = ref object of StreamState
+    stream: Stream
+    remaining: AsyncQueue[seq[byte]]
+  DrainingStreamError* = object of StreamError
+
+proc newDrainingStream*(messages: AsyncQueue[seq[byte]]): DrainingStream =
+  doAssert messages.len > 0
+  DrainingStream(remaining: messages)
+
+method enter(state: DrainingStream, stream: Stream) =
+  procCall enter(StreamState(state), stream)
+  state.stream = stream
+
+method leave(state: DrainingStream) =
+  state.stream = nil
+
+method read(state: DrainingStream): Future[seq[byte]] {.async.} =
+  result = state.remaining.popFirstNoWait()
+  if state.remaining.empty:
+    state.stream.switch(newClosedStream())
+
+method write(state: DrainingStream, bytes: seq[byte]) {.async.} =
+  raise newException(DrainingStreamError, "stream is draining")
+
+method close(state: DrainingStream) {.async.} =
+  state.stream.switch(newClosedStream())

--- a/quic/transport/ngtcp2/stream/openstate.nim
+++ b/quic/transport/ngtcp2/stream/openstate.nim
@@ -3,6 +3,7 @@ import pkg/ngtcp2
 import ../../stream
 import ../connection
 import ../errors
+import ./drainingstate
 import ./closedstate
 
 type
@@ -51,7 +52,10 @@ method close(state: OpenStream) {.async.} =
   state.stream.switch(newClosedStream())
 
 proc onClose*(state: OpenStream) =
-  state.stream.switch(newClosedStream())
+  if state.incoming.empty:
+    state.stream.switch(newClosedStream())
+  else:
+    state.stream.switch(newDrainingStream(state.incoming))
 
 proc receive*(state: OpenStream, bytes: seq[byte]) =
   state.incoming.putNoWait(bytes)

--- a/quic/transport/ngtcp2/streams.nim
+++ b/quic/transport/ngtcp2/streams.nim
@@ -19,6 +19,15 @@ proc onStreamOpen(conn: ptr ngtcp2_conn,
   let connection = cast[Ngtcp2Connection](user_data)
   connection.onIncomingStream(newStream(connection, stream_id))
 
+proc onStreamClose(conn: ptr ngtcp2_conn,
+                   stream_id: int64,
+                   app_error_code: uint64,
+                   user_data: pointer,
+                   stream_user_data: pointer): cint {.cdecl.} =
+  let openStream = cast[OpenStream](stream_user_data)
+  if openStream != nil:
+    openStream.onClose()
+
 proc onReceiveStreamData(connection: ptr ngtcp2_conn,
                           flags: uint32,
                           stream_id: int64,
@@ -37,4 +46,5 @@ proc onReceiveStreamData(connection: ptr ngtcp2_conn,
 
 proc installStreamCallbacks*(callbacks: var ngtcp2_conn_callbacks) =
   callbacks.stream_open = onStreamOpen
+  callbacks.stream_close = onStreamClose
   callbacks.recv_stream_data = onReceiveStreamData

--- a/tests/quic/testStreams.nim
+++ b/tests/quic/testStreams.nim
@@ -122,3 +122,18 @@ suite "streams":
       await serverStream.write(@[1'u8, 2'u8, 3'u8])
 
     await simulation.cancelAndWait()
+
+  test "reads last bytes from stream that is closed by peer":
+    let simulation = simulateNetwork(client, server)
+    let message = @[1'u8, 2'u8, 3'u8]
+
+    let clientStream = await client.openStream()
+    await clientStream.write(message)
+    await clientStream.close()
+    await sleepAsync(100.milliseconds) # wait for stream to be closed
+
+    let serverStream = await server.incomingStream()
+    let incoming = await serverStream.read()
+    check incoming == message
+
+    await simulation.cancelAndWait()

--- a/tests/quic/testStreams.nim
+++ b/tests/quic/testStreams.nim
@@ -102,3 +102,23 @@ suite "streams":
     check incoming == message
 
     await simulation.cancelAndWait()
+
+  test "raises when stream is closed by peer":
+    let simulation = simulateNetwork(client, server)
+
+    let clientStream = await client.openStream()
+    await clientStream.write(@[1'u8, 2'u8, 3'u8])
+
+    let serverStream = await server.incomingStream()
+    discard await serverStream.read()
+
+    await clientStream.close()
+    await sleepAsync(100.milliseconds) # wait for stream to be closed
+
+    expect IOError:
+      discard await serverStream.read()
+
+    expect IOError:
+      await serverStream.write(@[1'u8, 2'u8, 3'u8])
+
+    await simulation.cancelAndWait()


### PR DESCRIPTION
When we receive a message that a stream is closed by the peer, the stream state machine did not switch from `open` to `closed`. This led to the occasional failure that was observed in #21. This pull request ensures that it does switch to the `closed` state.

When the message queue for the stream is not yet empty, then the stream state will go from `open` to `draining`, allowing the messages in the queue to be read before switching to the `closed` state.

Fixes #21