### PR TITLE
Limit size of stream queue

### DIFF
--- a/quic/transport/ngtcp2/streams.nim
+++ b/quic/transport/ngtcp2/streams.nim
@@ -40,9 +40,6 @@ proc onReceiveStreamData(connection: ptr ngtcp2_conn,
   var bytes = newSeqUninitialized[byte](datalen)
   copyMem(bytes.toUnsafePtr, data, datalen)
   state.receive(bytes)
-  checkResult:
-    connection.ngtcp2_conn_extend_max_stream_offset(stream_id, datalen)
-  connection.ngtcp2_conn_extend_max_offset(datalen)
 
 proc installStreamCallbacks*(callbacks: var ngtcp2_conn_callbacks) =
   callbacks.stream_open = onStreamOpen


### PR DESCRIPTION
The `AsyncQueue` in `OpenStream` was not bound in size. This can lead to memory problems when the receiving peer cannot read fast enough to keep up with the sending peer. This PR fixes that by using the maximum stream offset from QUIC correctly.

Writing to streams is blocked when the maximum stream offset is reached. Previously we extended this offset when data was *added* to the read queue of the receiving peer. Now we only extend it once data has been *removed* from the queue, thereby limiting the queue size.