### PR TITLE
Handle errors in timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: iffy/install-nim@v3
+
+    # workaround for https://github.com/iffy/install-nim/issues/11
+    - name: Workaround SSL error with choosenim
+      run: |
+          curl -fO https://curl.se/ca/cacert.pem
+          install cacert.pem ~/.nimble/bin
+          ls ~/.nimble/bin
+      shell: bash
+      if: runner.os == 'Windows'
+
     - name: Build
       run: nimble install -y
     - name: Test

--- a/quic.nimble
+++ b/quic.nimble
@@ -6,9 +6,10 @@ license = "MIT"
 
 requires "nim >= 1.2.6"
 requires "stew >= 0.1.0 & < 0.2.0"
-requires "chronos >= 2.5.2 & < 3.0.0"
+requires "chronos >= 3.0.0 & < 4.0.0"
 requires "ngtcp2 >= 0.32.0 & < 0.33.0"
 requires "sysrandom >= 1.1.0 & < 2.0.0"
+requires "upraises >= 0.1.0 & < 0.2.0"
 requires "asynctest >= 0.2.1 & < 0.3.0"
 
 task lint, "format source files according to the official style guide":

--- a/quic/helpers/errorasdefect.nim
+++ b/quic/helpers/errorasdefect.nim
@@ -1,0 +1,5 @@
+template errorAsDefect*(body): untyped =
+  try:
+    body
+  except CatchableError as error:
+    raise (ref Defect)(msg: error.msg, parent: error)

--- a/quic/helpers/noerrors.nim
+++ b/quic/helpers/noerrors.nim
@@ -1,5 +1,0 @@
-## Include this file to indicate that your module does not raise Errors.
-## Disables compiler hints about unused declarations.
-
-{.push raises: [Defect].} # only defects are allowed
-{.push hint[XDeclaredButNotUsed]: off.} # disable hints that Defect is not used

--- a/quic/transport/ngtcp2/errors.nim
+++ b/quic/transport/ngtcp2/errors.nim
@@ -2,13 +2,12 @@ import pkg/ngtcp2
 
 type
   Ngtcp2Error* = object of IOError
-  Ngtcp2RecoverableError* = object of Ngtcp2Error
-  Ngtcp2FatalError* = object of Ngtcp2Error
+  Ngtcp2Defect* = object of Defect
 
 proc checkResult*(result: cint) =
   if result < 0:
     let msg = $ngtcp2_strerror(result)
     if ngtcp2_err_is_fatal(result) != 0:
-      raise newException(Ngtcp2FatalError, msg)
+      raise newException(Ngtcp2Defect, msg)
     else:
-      raise newException(Ngtcp2RecoverableError, msg)
+      raise newException(Ngtcp2Error, msg)

--- a/quic/transport/ngtcp2/stream/openstate.nim
+++ b/quic/transport/ngtcp2/stream/openstate.nim
@@ -26,7 +26,7 @@ proc setUserData(state: OpenStream, userdata: pointer) =
 proc clearUserData(state: OpenStream) =
   try:
     state.setUserData(nil)
-  except Ngtcp2RecoverableError:
+  except Ngtcp2Error:
     discard # stream already closed
 
 proc allowMoreIncomingBytes(state: OpenStream, amount: uint64) =

--- a/quic/transport/packets.nim
+++ b/quic/transport/packets.nim
@@ -1,9 +1,11 @@
+import pkg/upraises
 import ./packets/packet
 import ./packets/length
 import ./packets/read
 import ./packets/write
 import ../udp/datagram
-include ../helpers/noerrors
+
+push: {.upraises: [].}
 
 export packet
 export length

--- a/quic/transport/packets/length.nim
+++ b/quic/transport/packets/length.nim
@@ -1,7 +1,9 @@
+import pkg/upraises
 import ./varints
 import ./packet
 import ./packetnumber
-include ../../helpers/noerrors
+
+push: {.upraises: [].}
 
 proc len*(packet: Packet): int =
   case packet.form

--- a/quic/transport/packets/packet.nim
+++ b/quic/transport/packets/packet.nim
@@ -1,7 +1,9 @@
+import pkg/upraises
 import ../connectionid
 import ../version
 import ./packetnumber
-include ../../helpers/noerrors
+
+push: {.upraises: [].}
 
 export connectionid
 export PacketNumber

--- a/quic/transport/packets/read.nim
+++ b/quic/transport/packets/read.nim
@@ -1,9 +1,11 @@
 import pkg/stew/endians2
+import pkg/upraises
 import ../../helpers/bits
 import ./varints
 import ./packet
 import ./reader
-include ../../helpers/noerrors
+
+push: {.upraises: [].}
 
 export reader
 

--- a/quic/transport/quicclientserver.nim
+++ b/quic/transport/quicclientserver.nim
@@ -1,4 +1,5 @@
 import pkg/chronos
+import ../helpers/errorasdefect
 import ../udp/datagram
 import ./quicconnection
 import ./stream
@@ -9,7 +10,9 @@ proc newConnection(ngtcp2Connection: Ngtcp2Connection): QuicConnection =
   let state = newOpenConnection(ngtcp2Connection)
   let connection = newQuicConnection(state)
   ngtcp2Connection.onSend = proc(datagram: Datagram) =
-    connection.outgoing.putNoWait(datagram)
+    errorAsDefect:
+      connection.outgoing.putNoWait(datagram)
+
   ngtcp2Connection.onIncomingStream = proc(stream: Stream) =
     connection.incoming.putNoWait(stream)
   ngtcp2Connection.onHandshakeDone = proc =

--- a/quic/transport/timeout.nim
+++ b/quic/transport/timeout.nim
@@ -1,8 +1,9 @@
 import pkg/chronos
+import pkg/upraises
 
 type Timeout* = ref object
   timer: TimerCallback
-  onExpiry: proc () {.gcsafe.}
+  onExpiry: proc () {.gcsafe, upraises:[].}
   expired: AsyncEvent
 
 proc setTimer(timeout: Timeout, moment: Moment) =
@@ -13,7 +14,7 @@ proc setTimer(timeout: Timeout, moment: Moment) =
 
 const skip = proc () = discard
 
-proc newTimeout*(onExpiry: proc {.gcsafe.} = skip): Timeout =
+proc newTimeout*(onExpiry: proc () {.gcsafe, upraises:[].} = skip): Timeout =
   Timeout(onExpiry: onExpiry, expired: newAsyncEvent())
 
 proc stop*(timeout: Timeout) =


### PR DESCRIPTION
Latest version of Chronos disallows errors to escape from timeout callbacks. Any Errors that are raised in the connection timeout callback should not happen and are therefore are converted to Defects.

Uses `upraises` for exception tracking across Nim 1.2 and 1.4.
Fixes Ngtcp2 error hierarchy to match that of Nim; we now have an Ngtcp2Error and Ngtcp2Defect.