### PR TITLE
Drop connection when underlying UDP transport fails

### DIFF
--- a/tests/helpers/udp.nim
+++ b/tests/helpers/udp.nim
@@ -10,9 +10,12 @@ proc exampleQuicDatagram*: seq[byte] =
   result = newSeq[byte](4096)
   result.write(packet)
 
-proc sendTo*(datagram: seq[byte], remote: TransportAddress) {.async.} =
+proc newDatagramTransport*: DatagramTransport =
   proc onReceive(udp: DatagramTransport, remote: TransportAddress) {.async.} =
     discard
-  let udp = newDatagramTransport(onReceive)
+  newDatagramTransport(onReceive)
+
+proc sendTo*(datagram: seq[byte], remote: TransportAddress) {.async.} =
+  let udp = newDatagramTransport()
   await udp.sendTo(remote, datagram.toUnsafePtr, datagram.len)
   await udp.closeWait()

--- a/tests/quic/testConnection.nim
+++ b/tests/quic/testConnection.nim
@@ -1,0 +1,17 @@
+import pkg/asynctest
+import pkg/chronos
+import pkg/quic/connection
+import ../helpers/udp
+
+suite "connections":
+
+  let address = initTAddress("127.0.0.1:45346")
+
+  test "handles error when writing to udp transport by closing connection":
+    let udp = newDatagramTransport()
+    let connection = newOutgoingConnection(udp, address)
+
+    await udp.closeWait()
+    connection.startHandshake()
+
+    await connection.waitClosed()

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -5,6 +5,7 @@ import ./quic/testPacketLength
 import ./quic/testPackets
 import ./quic/testVarInts
 import ./quic/testPacketNumber
+import ./quic/testConnection
 import ./quic/testConnectionId
 import ./quic/testNgtcp2TransportParameters
 import ./quic/testParseDatagram


### PR DESCRIPTION
When the underlying UDP transport fails, make sure that it is handled gracefully.
Before this change, any TransportError would become a FutureDefect (and crash the application).