### PR TITLE
Revert "Switch to results.Opt"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 10
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]

--- a/quic/basics.nim
+++ b/quic/basics.nim
@@ -1,11 +1,17 @@
 import pkg/chronos
 import pkg/upraises
-import pkg/stew/results
+import std/options
 import ./udp/datagram
 import ./errors
 
 export chronos
+export options
 export datagram
-export results
 export errors
 export upraises
+
+template getOr*[T](o: Option[T], otherwise: untyped): T =
+  if o.isSome():
+    o.unsafeGet()
+  else:
+    otherwise

--- a/quic/connection.nim
+++ b/quic/connection.nim
@@ -12,7 +12,7 @@ type
     udp: DatagramTransport
     quic: QuicConnection
     loop: Future[void]
-    onClose: Opt[proc() {.gcsafe, upraises: [].}]
+    onClose: Option[proc() {.gcsafe, upraises: [].}]
     closed: AsyncEvent
   IncomingConnection = ref object of Connection
   OutgoingConnection = ref object of Connection
@@ -27,7 +27,7 @@ proc `onRemoveId=`*(connection: Connection, callback: IdCallback) =
   connection.quic.onRemoveId = callback
 
 proc `onClose=`*(connection: Connection, callback: proc() {.gcsafe, upraises: [].}) =
-  connection.onClose = Opt.some(callback)
+  connection.onClose = some callback
 
 proc drop*(connection: Connection) {.async.} =
   await connection.quic.drop()
@@ -69,9 +69,8 @@ proc newIncomingConnection*(udp: DatagramTransport,
   let quic = newQuicServerConnection(udp.localAddress, remote, datagram)
   let closed = newAsyncEvent()
   let connection = IncomingConnection(udp: udp, quic: quic, closed: closed)
-  proc onDisconnect {.async.} =
+  quic.disconnect = some proc {.async.} =
     await connection.disconnect()
-  quic.disconnect = Opt.some(onDisconnect)
   connection.startSending(remote)
   connection
 
@@ -80,9 +79,8 @@ proc newOutgoingConnection*(udp: DatagramTransport,
   let quic = newQuicClientConnection(udp.localAddress, remote)
   let closed = newAsyncEvent()
   let connection = OutgoingConnection(udp: udp, quic: quic, closed: closed)
-  proc onDisconnect {.async.} =
+  quic.disconnect = some proc {.async.} =
     await connection.disconnect()
-  quic.disconnect = Opt.some(onDisconnect)
   connection.startSending(remote)
   connection
 

--- a/quic/transport/ngtcp2/connection/closingstate.nim
+++ b/quic/transport/ngtcp2/connection/closingstate.nim
@@ -14,7 +14,7 @@ proc newClosingConnection*(finalDatagram: Datagram, ids: seq[ConnectionId],
   state
 
 proc sendFinalDatagram(state: ClosingConnection) =
-  let connection = state.connection.valueOr: return
+  let connection = state.connection.getOr: return
   try:
     connection.outgoing.putNoWait(state.finalDatagram)
   except AsyncQueueFullError:

--- a/quic/transport/ngtcp2/native/client.nim
+++ b/quic/transport/ngtcp2/native/client.nim
@@ -63,4 +63,4 @@ proc newNgtcp2Client*(local, remote: TransportAddress): Ngtcp2Connection =
     addr result[]
   )
 
-  result.conn = Opt.some(conn)
+  result.conn = conn.some

--- a/quic/transport/ngtcp2/native/ids.nim
+++ b/quic/transport/ngtcp2/native/ids.nim
@@ -26,7 +26,7 @@ proc getNewConnectionId(conn: ptr ngtcp2_conn,
 
   let
     connection = cast[Ngtcp2Connection](userData)
-    onNewId = connection.onNewId.valueOr: return
+    onNewId = connection.onNewId.getOr: return
   onNewId(newId)
 
 proc removeConnectionId(conn: ptr ngtcp2_conn,
@@ -34,7 +34,7 @@ proc removeConnectionId(conn: ptr ngtcp2_conn,
                         userData: pointer): cint {.cdecl.} =
   let
     connection = cast[Ngtcp2Connection](userData)
-    onRemoveId = connection.onRemoveId.valueOr: return
+    onRemoveId = connection.onRemoveId.getOr: return
   onRemoveId(id.toConnectionId)
 
 proc installConnectionIdCallback*(callbacks: var ngtcp2_conn_callbacks) =

--- a/quic/transport/ngtcp2/native/server.nim
+++ b/quic/transport/ngtcp2/native/server.nim
@@ -67,7 +67,7 @@ proc newNgtcp2Server*(local, remote: TransportAddress,
     addr result[]
   )
 
-  result.conn = Opt.some(conn)
+  result.conn = some conn
 
 proc extractIds(datagram: openArray[byte]): tuple[source, dest: ngtcp2_cid] =
   let info = parseDatagram(datagram)

--- a/quic/transport/ngtcp2/stream/drainingstate.nim
+++ b/quic/transport/ngtcp2/stream/drainingstate.nim
@@ -4,7 +4,7 @@ import ./closedstate
 
 type
   DrainingStream* = ref object of StreamState
-    stream: Opt[Stream]
+    stream: Option[Stream]
     remaining: AsyncQueue[seq[byte]]
   DrainingStreamError* = object of StreamError
 
@@ -16,22 +16,22 @@ proc newDrainingStream*(messages: AsyncQueue[seq[byte]]): DrainingStream =
 
 method enter(state: DrainingStream, stream: Stream) =
   procCall enter(StreamState(state), stream)
-  state.stream = Opt.some(stream)
+  state.stream = some stream
 
 method leave(state: DrainingStream) =
-  state.stream = Opt.none(Stream)
+  state.stream = Stream.none
 
 method read(state: DrainingStream): Future[seq[byte]] {.async.} =
   result = state.remaining.popFirstNoWait()
   if state.remaining.empty:
-    let stream = state.stream.valueOr: return
+    let stream = state.stream.getOr: return
     stream.switch(newClosedStream())
 
 method write(state: DrainingStream, bytes: seq[byte]) {.async.} =
   raise newException(DrainingStreamError, "stream is draining")
 
 method close(state: DrainingStream) {.async.} =
-  let stream = state.stream.valueOr: return
+  let stream = state.stream.getOr: return
   stream.switch(newClosedStream())
 
 method onClose(state: DrainingStream) =

--- a/quic/transport/ngtcp2/stream/openstate.nim
+++ b/quic/transport/ngtcp2/stream/openstate.nim
@@ -7,7 +7,7 @@ import ./closedstate
 
 type
   OpenStream* = ref object of StreamState
-    stream: Opt[Stream]
+    stream: Option[Stream]
     connection: Ngtcp2Connection
     incoming: AsyncQueue[seq[byte]]
 
@@ -18,7 +18,7 @@ proc newOpenStream*(connection: Ngtcp2Connection): OpenStream =
   )
 
 proc setUserData(state: OpenStream, userdata: pointer) =
-  let stream = state.stream.valueOr: return
+  let stream = state.stream.getOr: return
   state.connection.setStreamUserData(stream.id, userdata)
 
 proc clearUserData(state: OpenStream) =
@@ -36,30 +36,30 @@ proc allowMoreIncomingBytes(state: OpenStream, amount: uint64) =
 
 method enter(state: OpenStream, stream: Stream) =
   procCall enter(StreamState(state), stream)
-  state.stream = Opt.some(stream)
+  state.stream = some stream
   state.setUserData(unsafeAddr state[])
 
 method leave(state: OpenStream) =
   procCall leave(StreamState(state))
   state.clearUserData()
-  state.stream = Opt.none(Stream)
+  state.stream = Stream.none
 
 method read(state: OpenStream): Future[seq[byte]] {.async.} =
   result = await state.incoming.get()
   state.allowMoreIncomingBytes(result.len.uint64)
 
 method write(state: OpenStream, bytes: seq[byte]): Future[void] =
-  let stream = state.stream.valueOr:
+  let stream = state.stream.getOr:
     raise newException(QuicError, "stream is closed")
   state.connection.send(stream.id, bytes)
 
 method close(state: OpenStream) {.async.} =
-  let stream = state.stream.valueOr: return
+  let stream = state.stream.getOr: return
   state.connection.shutdownStream(stream.id)
   stream.switch(newClosedStream())
 
 method onClose*(state: OpenStream) =
-  let stream = state.stream.valueOr: return
+  let stream = state.stream.getOr: return
   if state.incoming.empty:
     stream.switch(newClosedStream())
   else:

--- a/quic/transport/quicconnection.nim
+++ b/quic/transport/quicconnection.nim
@@ -8,7 +8,7 @@ type
     outgoing*: AsyncQueue[Datagram]
     incoming*: AsyncQueue[Stream]
     handshake*: AsyncEvent
-    disconnect*: Opt[proc(): Future[void] {.gcsafe, upraises: [].}]
+    disconnect*: Option[proc(): Future[void] {.gcsafe, upraises: [].}]
     onNewId*: IdCallback
     onRemoveId*: IdCallback
   ConnectionState* = ref object of RootObj

--- a/quic/transport/timeout.nim
+++ b/quic/transport/timeout.nim
@@ -1,7 +1,7 @@
 import ../basics
 
 type Timeout* = ref object
-  timer: Opt[TimerCallback]
+  timer: Option[TimerCallback]
   onExpiry: proc () {.gcsafe, upraises:[].}
   expired: AsyncEvent
 
@@ -9,7 +9,7 @@ proc setTimer(timeout: Timeout, moment: Moment) =
   proc onTimeout(_: pointer) =
     timeout.expired.fire()
     timeout.onExpiry()
-  timeout.timer = Opt.some(setTimer(moment, onTimeout))
+  timeout.timer = some setTimer(moment, onTimeout)
 
 const skip = proc () = discard
 

--- a/tests/quic/testNgtcp2TransportParameters.nim
+++ b/tests/quic/testNgtcp2TransportParameters.nim
@@ -1,6 +1,6 @@
+import std/options
 import pkg/unittest2
 import pkg/ngtcp2
-import pkg/stew/results
 import pkg/quic/errors
 import pkg/quic/transport/ngtcp2/native/connection
 import pkg/quic/transport/ngtcp2/native/client
@@ -32,5 +32,5 @@ suite "ngtcp2 transport parameters":
     settings.transport_params.active_connection_id_limit = 0
 
     expect QuicError:
-      let conn = connection.conn.get()
+      let conn = connection.conn.unsafeGet()
       conn.setRemoteTransportParameters(settings.transport_params)


### PR DESCRIPTION
Reverts status-im/nim-quic#38

I forgot that Opt & options don't have the same semantics wrt nil pointers, we cannot just switch to Opt unfortunately