### PR TITLE
wip: close conn on fatal

### DIFF
--- a/quic/transport/ngtcp2/connstate/openstate.nim
+++ b/quic/transport/ngtcp2/connstate/openstate.nim
@@ -10,6 +10,7 @@ import ../native/connection
 import ../native/streams
 import ../native/errors
 import ./closingstate
+import ./closedstate
 import ./drainingstate
 import ./disconnectingstate
 import ./openstreams
@@ -81,16 +82,24 @@ method ids(state: OpenConnection): seq[ConnectionId] {.raises: [].} =
   state.ngtcp2Connection.ids
 
 method send(state: OpenConnection) {.raises: [QuicError].} =
-  state.ngtcp2Connection.send()
+  try:
+    state.ngtcp2Connection.send()
+  except Ngtcp2FatalError as e:
+    discard state.close()
+    raise newException(QuicError, "Received fatal error: " & e.msg, e)
 
 method receive(state: OpenConnection, datagram: sink Datagram) {.raises: [QuicError].} =
   var errCode = 0
   var errMsg = ""
   try:
     state.ngtcp2Connection.receive(datagram)
-  except Ngtcp2Error as exc:
-    errCode = exc.code
-    errMsg = exc.msg
+  except Ngtcp2FatalError as e:
+    errCode = e.code
+    errMsg = e.msg
+    trace "ngtcp2 fatal error on receive", code = errCode, msg = errMsg
+  except Ngtcp2Error as e:
+    errCode = e.code
+    errMsg = e.msg
     trace "ngtcp2 error on receive", code = errCode, msg = errMsg
   finally:
     let quicConnection = state.quicConnection.valueOr:
@@ -124,13 +133,22 @@ method openStream(
 method close(state: OpenConnection) {.async: (raises: [CancelledError, QuicError]).} =
   let quicConnection = state.quicConnection.valueOr:
     return
-  let finalDatagram = state.ngtcp2Connection.close()
-  let duration = state.ngtcp2Connection.closingDuration()
-  let ids = state.ids
-  let closing =
-    newClosingConnection(finalDatagram, ids, duration, state.derCertificates)
-  quicConnection.switch(closing)
-  await closing.close()
+
+  try:
+    let finalDatagram = state.ngtcp2Connection.close()
+    let duration = state.ngtcp2Connection.closingDuration()
+    let closing =
+      newClosingConnection(finalDatagram, state.ids, duration, state.derCertificates)
+    quicConnection.switch(closing)
+    await closing.close()
+  except Ngtcp2FatalError as e:
+    let closed = newClosedConnection(state.derCertificates)
+    quicConnection.switch(closed)
+    raise newException(
+      QuicError,
+      "failed to gracefully close connection: received fatal error: " & e.msg,
+      e,
+    )
 
 method drop(state: OpenConnection) {.async: (raises: [CancelledError, QuicError]).} =
   trace "Dropping OpenConnection state"

--- a/quic/transport/ngtcp2/native/connection.nim
+++ b/quic/transport/ngtcp2/native/connection.nim
@@ -168,7 +168,7 @@ template pendingAckQueue*(
 
 proc send*(
     connection: Ngtcp2Connection, streamId: int64, bytes: seq[byte], isFin: bool = false
-) {.async: (raises: [CancelledError, QuicError, Ngtcp2Error, Ngtcp2FatalError]).} =
+) {.async: (raises: [CancelledError, QuicError, Ngtcp2FatalError]).} =
   ## Send payloads
   var messagePtr = bytes.toUnsafePtr
   var messageLen = bytes.len.uint

--- a/quic/transport/ngtcp2/native/connection.nim
+++ b/quic/transport/ngtcp2/native/connection.nim
@@ -226,8 +226,8 @@ proc handleTimeout(connection: Ngtcp2Connection) =
       checkResult ret
       connection.send()
   except Ngtcp2FatalError as e:
-    # TODO how to close?
-    error "handleTimeout unexpected error", msg = e.msg
+    error "handleTimeout fatal error", msg = e.msg
+    # connection could not be closed here, upper layers need to transition to closed state.
   except QuicError as e:
     error "handleTimeout unexpected error", msg = e.msg
 

--- a/quic/transport/ngtcp2/native/connection.nim
+++ b/quic/transport/ngtcp2/native/connection.nim
@@ -113,7 +113,7 @@ proc trySend(
   buffer.setLen(length)
   return Datagram(data: buffer, ecn: ECN(packetInfo.ecn))
 
-proc send*(connection: Ngtcp2Connection) {.raises: [QuicError].} =
+proc send*(connection: Ngtcp2Connection) {.raises: [QuicError, Ngtcp2FatalError].} =
   ## Send control flow messages
   while true:
     var buffer = newSeqUninit[byte](writeBufferSize)
@@ -129,7 +129,7 @@ proc send(
     messagePtr: ptr byte,
     messageLen: uint,
     isFin: bool = false,
-): Future[int] {.async: (raises: [CancelledError, QuicError]).} =
+): Future[int] {.async: (raises: [CancelledError, QuicError, Ngtcp2FatalError]).} =
   var written: int
   var buffer = newSeqUninit[byte](writeBufferSize)
   var datagram =
@@ -168,7 +168,7 @@ template pendingAckQueue*(
 
 proc send*(
     connection: Ngtcp2Connection, streamId: int64, bytes: seq[byte], isFin: bool = false
-) {.async: (raises: [CancelledError, QuicError]).} =
+) {.async: (raises: [CancelledError, QuicError, Ngtcp2Error, Ngtcp2FatalError]).} =
   ## Send payloads
   var messagePtr = bytes.toUnsafePtr
   var messageLen = bytes.len.uint
@@ -225,6 +225,9 @@ proc handleTimeout(connection: Ngtcp2Connection) =
     else:
       checkResult ret
       connection.send()
+  except Ngtcp2FatalError as e:
+    # TODO how to close?
+    error "handleTimeout unexpected error", msg = e.msg
   except QuicError as e:
     error "handleTimeout unexpected error", msg = e.msg
 

--- a/quic/transport/ngtcp2/native/errors.nim
+++ b/quic/transport/ngtcp2/native/errors.nim
@@ -1,24 +1,24 @@
 import ngtcp2
-import chronicles
 import ../../../errors
-
-logScope:
-  topics = "ngtcp2 error"
 
 type Ngtcp2Error* = ref object of QuicError
   code*: cint
-  isFatal*: bool
 
-proc checkResult*(result: cint) {.raises: [Ngtcp2Error].} =
-  if result >= 0:
+# Note: Ngtcp2FatalError is intentionally not ref object of QuicError
+# because it needs different case for handling compared to QuicError.
+# If it was QuicError, it would be hard to notice places where we need handle this error.
+type Ngtcp2FatalError* = ref object of CatchableError
+  code*: cint
+
+proc checkResult*(retCode: cint) {.raises: [QuicError, Ngtcp2FatalError].} =
+  if retCode >= 0:
     return
 
+  if ngtcp2_err_is_fatal(retCode) != 0:
+    let e = new(Ngtcp2FatalError)
+    e.code = retCode
+    raise e
+
   let e = new(Ngtcp2Error)
-  e.code = result
-  e.isFatal = ngtcp2_err_is_fatal(result) != 0
-  e.msg = $ngtcp2_strerror(result)
-
-  if e.isFatal:
-    error "Created fatal error", code = e.code, msg = e.msg
-
+  e.code = retCode
   raise e

--- a/quic/transport/ngtcp2/native/streams.nim
+++ b/quic/transport/ngtcp2/native/streams.nim
@@ -3,7 +3,7 @@ import ../../../helpers/[openarray, sequninit]
 import ../../../errors
 import ../../stream
 import ../streamstate/openstate
-import ./connection
+import ./[connection, errors]
 import chronicles
 
 logScope:
@@ -14,12 +14,15 @@ proc openStream*(
 ): Stream {.raises: [QuicError].} =
   let stream = newStream()
   stream.switch(newOpenStreamState(connection, stream))
-  let id =
-    if unidirectional:
-      connection.openUniStream(addr stream[])
-    else:
-      connection.openBidiStream(addr stream[])
-  stream.id = id
+  try:
+    let id =
+      if unidirectional:
+        connection.openUniStream(addr stream[])
+      else:
+        connection.openBidiStream(addr stream[])
+    stream.id = id
+  except Ngtcp2FatalError as e:
+    raise newException(QuicError, "received fatal error: " & e.msg, e)
   return stream
 
 proc onStreamOpen(

--- a/quic/transport/ngtcp2/streamstate/basestate.nim
+++ b/quic/transport/ngtcp2/streamstate/basestate.nim
@@ -18,22 +18,5 @@ method onLeave*(state: BaseStreamState) =
 method expire*(state: BaseStreamState) {.raises: [].} =
   state.stream.closed.fire()
 
-method write*(
-    state: BaseStreamState, bytes: seq[byte]
-) {.async: (raises: [CancelledError, QuicError]).} =
-  await state.connection.send(state.stream.id, bytes)
-
-proc allowMoreIncomingBytes*(state: BaseStreamState, amount: uint64) =
-  state.connection.extendStreamOffset(state.stream.id, amount)
-  state.connection.send()
-
-proc sendFin*(state: BaseStreamState) =
-  if not state.finSent:
-    state.finSent = true
-    discard state.connection.send(state.stream.id, @[], true)
-
-proc reset*(state: BaseStreamState) {.raises: [QuicError].} =
-  state.connection.shutdownStream(state.stream.id)
-
 proc switch*(state: BaseStreamState, nextState: StreamState) {.raises: [QuicError].} =
   state.stream.switch(nextState)

--- a/quic/transport/ngtcp2/streamstate/closestate.nim
+++ b/quic/transport/ngtcp2/streamstate/closestate.nim
@@ -23,8 +23,8 @@ proc doReset(state: ClosedStreamState) {.raises: [QuicError].} =
   try:
     state.connection.shutdownStream(state.stream.id)
   except Ngtcp2FatalError:
-    # do nothing we are already in closed connection
-    discard  
+    # do nothing here, state is already in closed connection
+    discard
 
 proc sendFin(state: ClosedStreamState) =
   if not state.finSent:

--- a/quic/transport/ngtcp2/streamstate/closestate.nim
+++ b/quic/transport/ngtcp2/streamstate/closestate.nim
@@ -1,6 +1,7 @@
 import ../../../errors
 import ../../../basics
 import ../../stream
+import ../native/[connection, errors]
 import ./queue
 import ./basestate
 
@@ -18,13 +19,25 @@ proc newClosedStreamState*(
     wasReset: wasReset,
   )
 
+proc doReset(state: ClosedStreamState) {.raises: [QuicError].} =
+  try:
+    state.connection.shutdownStream(state.stream.id)
+  except Ngtcp2FatalError:
+    # do nothing we are already in closed connection
+    discard  
+
+proc sendFin(state: ClosedStreamState) =
+  if not state.finSent:
+    state.finSent = true
+    discard state.connection.send(state.stream.id, @[], true)
+
 method onEnter*(state: ClosedStreamState) {.raises: [QuicError].} =
   procCall onEnter(BaseStreamState(state))
   if state.wasReset:
     state.queue.reset()
   state.queue.close()
   if state.wasReset:
-    state.reset()
+    state.doReset()
   else:
     state.sendFin()
   state.stream.closed.fire()

--- a/quic/transport/ngtcp2/streamstate/openstate.nim
+++ b/quic/transport/ngtcp2/streamstate/openstate.nim
@@ -1,6 +1,6 @@
 import ../../../basics
 import ../../stream
-import ../native/connection
+import ../native/[connection, errors]
 import ./queue
 import ./basestate
 import ./closestate
@@ -13,6 +13,14 @@ proc newOpenStreamState*(
     connection: Ngtcp2Connection, stream: Stream
 ): OpenStreamState =
   OpenStreamState(connection: connection, stream: stream, queue: initStreamQueue())
+
+proc allowMoreIncomingBytes(state: OpenStreamState, amount: uint64) =
+  try:
+    state.connection.extendStreamOffset(state.stream.id, amount)
+    state.connection.send()
+  except Ngtcp2FatalError as e:
+    state.switch(newClosedStreamState(state))
+    raise newException(QuicError, "received fatal error: " & e.msg, e)
 
 method read*(
     state: OpenStreamState
@@ -38,7 +46,11 @@ method read*(
 method write*(
     state: OpenStreamState, bytes: seq[byte]
 ) {.async: (raises: [CancelledError, QuicError]).} =
-  await procCall BaseStreamState(state).write(bytes)
+  try:
+    await state.connection.send(state.stream.id, bytes)
+  except Ngtcp2FatalError as e:
+    state.switch(newClosedStreamState(state))
+    raise newException(QuicError, "received fatal error: " & e.msg, e)
 
 method close*(state: OpenStreamState) {.async: (raises: [CancelledError, QuicError]).} =
   state.switch(newReceiveStreamState(state))

--- a/quic/transport/ngtcp2/streamstate/receivestate.nim
+++ b/quic/transport/ngtcp2/streamstate/receivestate.nim
@@ -1,5 +1,6 @@
 import ../../../errors
 import ../../../basics
+import ../native/[connection, errors]
 import ./queue
 import ./basestate
 import ./closestate
@@ -14,9 +15,21 @@ proc newReceiveStreamState*(base: BaseStreamState): ReceiveStreamState =
     finSent: base.finSent,
   )
 
+proc sendFin(state: ReceiveStreamState) =
+  state.finSent = true
+  discard state.connection.send(state.stream.id, @[], true)
+
 method onEnter*(state: ReceiveStreamState) {.raises: [QuicError].} =
   procCall onEnter(BaseStreamState(state))
   state.sendFin()
+
+proc allowMoreIncomingBytes(state: ReceiveStreamState, amount: uint64) =
+  try:
+    state.connection.extendStreamOffset(state.stream.id, amount)
+    state.connection.send()
+  except Ngtcp2FatalError as e:
+    state.switch(newClosedStreamState(state))
+    raise newException(QuicError, "received fatal error: " & e.msg, e)
 
 method read*(
     state: ReceiveStreamState

--- a/quic/transport/ngtcp2/streamstate/sendstate.nim
+++ b/quic/transport/ngtcp2/streamstate/sendstate.nim
@@ -1,5 +1,6 @@
 import ../../../errors
 import ../../../basics
+import ../native/[connection, errors]
 import ./queue
 import ./basestate
 import ./closestate
@@ -26,7 +27,11 @@ method read*(
 method write*(
     state: SendStreamState, bytes: seq[byte]
 ) {.async: (raises: [CancelledError, QuicError]).} =
-  await procCall BaseStreamState(state).write(bytes)
+  try:
+    await state.connection.send(state.stream.id, bytes)
+  except Ngtcp2FatalError as e:
+    state.switch(newClosedStreamState(state))
+    raise newException(QuicError, "received fatal error: " & e.msg, e)
 
 method close*(state: SendStreamState) {.async: (raises: [CancelledError, QuicError]).} =
   state.switch(newClosedStreamState(state))


### PR DESCRIPTION
when ngtcp2 receives fatal error connection needs to be closed. but things become tricky now, because native connection can't close it, upper layers (connection and stream sates) need to transition to closed states.

to deal with this, new special fatal error is created on ngtcp2 calls, and propagated from native calls. special error is there to enforce compile time errors if it is not handled. 
stream and connection must handle fatal errors to best of their abilities.